### PR TITLE
Added addresses for Hand to Hand - An Adamant Addon

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -328,8 +328,8 @@ id,sse,vr,status,name
 50978,0x14088e280,0x1408bba50,3,EssentialFavorites::Dropped::IsQuestObject
 50980,0x14088e890,0x1408bc060,3,InventoryMenu::GetItemChargedEventSource
 51081,0x140896ac0,0x1408c4770,3,LockVariations::Model::RequestModel
-51084,0x1408971a0,0x1408C4E40,3,LockPickMenuXPProgress::LockPickMenuSkillLevel
-51088,0x140897e10,0x1408C5AB0,3,LockPickSkills
+51084,0x1408971a0,0x1408C4E40,1,LockPickMenuXPProgress::LockPickMenuSkillLevel
+51088,0x140897e10,0x1408C5AB0,1,LockPickSkills
 51093,0x1408983e0,0x1408c6080,3,RememberLockpickAngle::LockpickBreakAddr
 51094,0x1408987d0,0x1408c6500,3,LockVariations::Sound::update_pick_angle
 51096,0x140898cd0,0x1408c69f0,3,LockVariations::Sound::update_lock_angle

--- a/database.csv
+++ b/database.csv
@@ -328,6 +328,8 @@ id,sse,vr,status,name
 50978,0x14088e280,0x1408bba50,3,EssentialFavorites::Dropped::IsQuestObject
 50980,0x14088e890,0x1408bc060,3,InventoryMenu::GetItemChargedEventSource
 51081,0x140896ac0,0x1408c4770,3,LockVariations::Model::RequestModel
+51084,0x1408971a0,0x1408C4E40,3,LockPickMenuXPProgress::LockPickMenuSkillLevel
+51088,0x140897e10,0x1408C5AB0,3,LockPickSkills
 51093,0x1408983e0,0x1408c6080,3,RememberLockpickAngle::LockpickBreakAddr
 51094,0x1408987d0,0x1408c6500,3,LockVariations::Sound::update_pick_angle
 51096,0x140898cd0,0x1408c69f0,3,LockVariations::Sound::update_lock_angle

--- a/database.csv
+++ b/database.csv
@@ -328,8 +328,8 @@ id,sse,vr,status,name
 50978,0x14088e280,0x1408bba50,3,EssentialFavorites::Dropped::IsQuestObject
 50980,0x14088e890,0x1408bc060,3,InventoryMenu::GetItemChargedEventSource
 51081,0x140896ac0,0x1408c4770,3,LockVariations::Model::RequestModel
-51084,0x1408971a0,0x1408C4E40,1,LockPickMenuXPProgress::LockPickMenuSkillLevel
-51088,0x140897e10,0x1408C5AB0,1,LockPickSkills
+51084,0x1408971a0,0x1408c4e40,3,handtohand::LockpickingMenu::LockPickMenuSkillLevel
+51088,0x140897e10,0x1408c5ab0,3,handtohand::LockpickingMenu::LockPickSkills
 51093,0x1408983e0,0x1408c6080,3,RememberLockpickAngle::LockpickBreakAddr
 51094,0x1408987d0,0x1408c6500,3,LockVariations::Sound::update_pick_angle
 51096,0x140898cd0,0x1408c69f0,3,LockVariations::Sound::update_lock_angle


### PR DESCRIPTION
This commit adds  VR addresses for 51084 and 51088. I did this using almost entirely automated tools so I'm not 100% it's completely correct, but having compiled and tested it in-game with the respective mod, it does seem that it allows the mod to function properly having tested what should be the affected actions.

I'm setting to confidence 1 as while I did test in-game and they seem to function as intended, I've largely hit some of my time constraints before I will be too busy to look more in-depth into the decompiled executables to verify further and the values were basically automated.

As well, I'm not 100% sure on naming, but I'm referencing what they are called in the source code for Hand to Hand's DLL.