### PR TITLE
Add offsets used in CommonLibSSE NG/po3 forks and Fully Dynamic Game Engine

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1,5 +1,7 @@
 id,sse,vr,status,name
+10827,0x1400f6e80,0x140107430,3,RE::TESForm::GetFormEditorID
 10878,0x1400f7210,0x1401077c0,3,RE::Offset::BGSDefaultObjectManager::GetSingleton
+10883,0x1400f72e0,0x140107890,3,RE::TESForm::SetFormEditorID
 10974,0x1400f9ca0,0x14010a250,3,RE::INISettingCollection::Unk_07
 10979,0x1400f9e90,0x14010a440,3,RE::Offset::BSString::Set_CStr
 11045,0x1400fcfe0,0x14010d590,3,RE::Offset::MemoryManager::GetSingleton
@@ -30,11 +32,15 @@ id,sse,vr,status,name
 13202,0x140156b60,0x1401675b0,3,RE::TES::GetLandTexture
 13203,0x140156cd0,0x140167720,3,RE::TES::GetLandMaterialType
 13212,0x140157360,0x140167db0,3,RE::TES::GetWaterHeight
+13221,0x1401580c0,0x140168b70,3,RE::TES::Pick
 13224,0x140158350,0x140168e00,3,po3tweaks::ToggleCollisionFix::ToggleCollision
 13530,0x1401652d0,0x140175a10,3,RE::Offset::UIMessageQueue::AddMessage
 13625,0x14016c210,0x14017cc30,3,RE::Offset::TESDataHandler::CreateReferenceAtLocation
+13594,0x140167220,0x140177940,3,FDGE::Skyrim::LoadWorldData
+13625,0x14016c210,0x14017cc30,3,RE::TESDataHandler::CreateReferenceAtLocation
 13657,0x1401713d0,0x140181b80,3,RE::Offset::TESDataHandler::LoadScripts
 13789,0x140177790,0x1401876a0,3,RE::Offset::Sky::GetSingleton
+13889,0x14017cc90,0x14018CAA0,3,FDGE::Skyrim::SkipGrup
 13897,0x14017d4c0,0x14018d2a0,3,RE::Offset::TESFile::GetFormType
 13898,0x14017d550,0x14018d330,3,RE::Offset::TESFile::Seek
 13902,0x14017d910,0x14018d6f0,3,RE::Offset::TESFile::GetCurrentSubRecordType
@@ -50,6 +56,7 @@ id,sse,vr,status,name
 14399,0x140190480,0x1401a01b0,3,RE::Offset::TESDescription::GetDescription
 14509,0x1401957e0,0x1401a5510,2,RE::TESForm::AddCompileIndex
 14704,0x14019d510,0x1401ad250,3,RE::TESHarvestedEvent::GetEventSource
+14809,0x1401a1730,0x1401b1470,3,RE::TESForm::GetWeight
 15118,0x1401b13f0,0x1401c1400,3,RE::BGSDecalManager::RemoveItem
 15204,0x1401b4b20,0x1401c4b30,3,SeasonsofSkyrim::LandscapeSwap::LoadGrassType::add_cell_grass
 15205,0x1401b5750,0x1401c5760,3,SeasonsofSkyrim::LandscapeSwap::LoadGrassType::add_cell_grass_from_buffer
@@ -75,6 +82,7 @@ id,sse,vr,status,name
 15829,0x1401e08b0,0x1401f1470,3,RE::InventoryChanges::InitScripts
 15858,0x1401e5390,0x1401f5f50,2,papyrus_extender::fave_util::item::favorite
 15859,0x1401e58f0,0x1401f64b0,2,papyrus_extender::fave_util::item::unfavorite
+15868,0x1401e7310,0x1401f7ed0,3,RE::InventoryChanges::GetItemCount
 15889,0x1401e9d90,0x1401fa900,3,RE::InventoryChanges::InitLeveledItems
 15890,0x1401ea020,0x1401fab90,3,RE::InventoryChanges::InitFromContainerExtra
 15907,0x1401ecc60,0x1401fd7d0,3,RE::Offset::InventoryChanges::SetUniqueID
@@ -199,11 +207,12 @@ id,sse,vr,status,name
 35317,0x1405a2930,0x1405a9ff0,3,RE::Offset::BGSImpactManager::PlayImpactSound
 35320,0x1405a2c60,0x1405aa320,4,RE::Offset::BGSImpactManager::PlayImpactEffect
 35413,0x1405a6640,0x1405add00,3,RE::Calendar::GetTimeDateString
-35548,0x1405ae010,0x1405b5880,3,ScaleformTranslationpp::BSScaleformMovieLoaderEx::Ctor
+35548,0x1405ae010,0x1405b5880,3,main
 35882,0x1405c0610,0x1405c8b30,3,po3tweaks::ScreenshotToConsole::DebugNotification
 35978,0x1405c5220,0x1405cd7c0,3,RE::TaskQueueInterface::QueueBulletWaterDisplacementTask
 35987,0x1405c58c0,0x1405cde60,2,RE::TaskQueueInterface::QueueRemoveSpellTask
 36198,0x1405ce240,0x1405d6840,3,po3tweaks::Spell::ReapplyOnDeath::Load3d
+36392,0x1405da840,0x1405e2ec0,3,RE::Actor::CalculateCurrentVendorFaction
 36602,0x1405edd50,0x1405f6460,3,RE::Offset::Actor::SetRotationX
 36604,0x1405edef0,0x1405f6600,3,RE::Offset::Actor::SetLifeState
 36248,0x1405d0fc0,0x1405d95a0,3,RE::Offset::Actor::SetRotationZ
@@ -222,8 +231,8 @@ id,sse,vr,status,name
 36456,0x1405e1860,0x1405e9ee0,3,RE::Actor::GetTotalCarryWeight_1405E1860
 36523,0x1405e6b50,0x1405ef270,3,EssentialFavorites::Disarm::IsQuestObject
 36532,0x1405e7500,0x1405efc20,3,RE::Offset::Actor::CanAttackActor
-36541,0x1405e8700,0x1405f0e20,3,po3tweaks::VoiceModulation::SetObjectToFollow
 36537,0x1405e7e40,0x1405f0560,3,RE::Offset::Actor::GetHostileToActor
+36541,0x1405e8700,0x1405f0e20,3,po3tweaks::VoiceModulation::SetObjectToFollow
 36631,0x1405f2530,0x1405fac70,3,RE::Actor::Decapitate
 36678,0x1405f8430,0x140600ba0,3,RE::Actor::AddToFaction
 36682,0x1405f87f0,0x140600f60,3,RE::Actor::CreateBlood
@@ -331,6 +340,7 @@ id,sse,vr,status,name
 42928,0x14074b170,0x140776440,3,StaminaNPC::apply_deny_bow_Player
 43022,0x1407531c0,0x14077e4e0,2,papyrus_extender::events::game::weaponhit::projectile::target_0x38d
 43030,0x140754820,0x14077fbd0,3,po3tweaks::ProjectileRange::UpdateCombatThreat
+43103,0x140759360,0x1407846b0,3,RE::VATS::SetMagicTimeSlowdown
 43571,0x140772a60,0x14079ddb0,3,po3tweaks::CombatDialogue::SayCombatDialogue
 44036,0x140785f80,0x1407b12d0,3,enhanced_reanimation::CombatMagicCasterReanimate::CheckShouldEquip
 49311,0x14083c870,0x140867b70,3,RE::CombatApproachTargetSpeedController::sub_14083C870
@@ -342,6 +352,9 @@ id,sse,vr,status,name
 49755,0x140845e20,0x1408710d0,3,StaminaNPC::apply_get_CombatBashChance
 49756,0x140845e80,0x140871130,3,StaminaNPC::apply_get_OffensiveBashChance
 49772,0x140846580,0x140871830,3,StaminaNPC::apply_get_CombatRangedAttackChance
+49858,0x14084b200,0x140876550,2,RE::PlayerCamera::ForceFirstPerson
+49863,0x14084b350,0x140876610,2,RE::PlayerCamera::ForceThirdPerson
+49876,0x14084b720,0x140876880,2,RE::PlayerCamera::ToggleFreeCameraMode
 49908,0x14084d630,0x140877db0,3,RE::Offset::PlayerCamera::UpdateThirdPerson
 50061,0x140855b60,0x14087ff20,3,EssentialFavorites::Barter::IsQuestObject
 50099,0x140856a50,0x140880e10,3,RE::Offset::ItemList::Update
@@ -398,11 +411,17 @@ id,sse,vr,status,name
 52236,0x1408e7c80,0x14091a4e0,3,anonymous_namespace__FastTravelConfirmCallback::Run_1408E7C80
 52374,0x1408ef500,0x140924430,3,QuickLoot::
 52400,0x1408f03c0,0x1409254b0,3,QuickLoot::
+52652,0x140902560,0x14093CCE0,3,RE::SkyrimScript::HandlePolicy::HandleIsType
+52653,0x140902770,0x14093CEF0,3,RE::SkyrimScript::HandlePolicy::IsHandleObjectAvailable
+52655,0x140902860,0x14093CFE0,3,RE::SkyrimScript::HandlePolicy::GetHandleForObject
+52659,0x140902b00,0x14093D280,3,RE::SkyrimScript::HandlePolicy::GetObjectForHandle
+52662,0x1409032c0,0x14093DA40,3,RE::SkyrimScript::HandlePolicy::ConvertHandleToString
 53029,0x14091c620,0x140956da0,3,RE::Offset::Actor::HasLOS
 53144,0x1409252c0,0x14095fd10,3,RE::Offset::SkyrimVM::QueuePostRenderCall
 53209,0x14092b8e0,0x140965fe0,3,RE::Offset::SkyrimVM::DumpStacks
 53948,0x14094d850,0x140987ab0,3,papyrus::Actor::TrapSoul
 54836,0x1409731b0,0x1409ad050,3,papyrus__Game::getplayer_1409731B0
+55141,0x140980190,0x1409BAF10,3,FDGE::BSScript::InitializeScriptTypes
 55352,0x140988450,0x1409c35d0,2,po3tweaks::GameTimers::SetGlobal
 55945,0x1409a4050,0x1409deb70,3,SPID:Distribute::DeathItemManager::Detail::Add_item
 56227,0x1409ae5c0,0x1409e90e0,3,RE::Offset::TESObjectREFR::MoveTo
@@ -473,6 +492,7 @@ id,sse,vr,status,name
 69447,0x140c6d5e0,0x140cb3770,3,RE::NiTimeController::ComputeScaledTime
 69449,0x140c6d810,0x140cb39a0,3,RE::NiTimeController::ProcessClone
 69459,0x140c6da50,0x140cb3be0,3,AnimationMotionRevoluation::MotionDataContainer::InterpolateRotation
+69564,0x140c72300,0x140cb86b0,3,RE::BSDynamicTriShape::BSDynamicTriShape
 69636,0x140c76060,0x140cbc490,3,RE::Offset::BSResourceNiBinaryStream::Ctor
 69638,0x140c76340,0x140cbc770,3,RE::Offset::BSResourceNiBinaryStream::Dtor
 69640,0x140c76490,0x140cbc8c0,3,RE::Offset::BSResourceNiBinaryStream::Seek
@@ -483,6 +503,7 @@ id,sse,vr,status,name
 74237,0x140d38310,0x14053c550,3,RE::INISettingCollection::ReadSetting
 74239,0x140d38710,0x140d80bb0,3,RE::INISettingCollection::OpenHandle
 74240,0x140d38720,0x140d80bc0,3,RE::INISettingCollection::CloseHandle
+75507,0x140d6dbc0,0x140dbf9b0,3,RE::RendererData::CreateRenderTexture
 76033,0x140da81e0,0x140dfd160,3,RE::Offset::NiAVObject::SetMotionType
 76170,0x140dae3d0,0x140e03350,3,RE::Offset::NiAVObject::SetCollisionLayer
 76171,0x140dae3f0,0x140e03370,3,RE::NiAVObject::UpdateRigidBodySettings
@@ -509,6 +530,7 @@ id,sse,vr,status,name
 80265,0x140ecc960,0x140f294b0,3,RE::Offset::GFxValue::ObjectInterface::SetElement
 80268,0x140eccba0,0x140f296f0,3,RE::Offset::GFxValue::ObjectInterface::SetMember
 80270,0x140ecccf0,0x140f29840,3,RE::Offset::GFxValue::ObjectInterface::SetText
+80300,0x140ece0d0,0x140f2adc0,3,ScaleformTranslationpp::BSScaleformMovieLoaderEx::Ctor
 80302,0x140ece790,0x140f2b480,3,RE::Offset::BSScaleformManager::LoadMovie
 80446,0x140ed3a50,0x140f2da40,3,RE::Offset::GString::Ctor
 80547,0x140ed80b0,0x140f30f20,3,RE::Offset::GFxMovieView::InvokeNoReturn
@@ -524,6 +546,8 @@ id,sse,vr,status,name
 97742,0x1412444c0,0x14129a210,3,RE::Offset::BSScript::Stack::Dtor
 97746,0x1412449d0,0x14129a720,3,RE::Offset::BSScript::Stack::GetStackFrameVariable
 97923,0x1412507f0,0x14129dd90,3,RE::Offset::BSScript::NF_util::NativeFunctionBase::Call
+98160,0x141266030,0x141285B00,3,RE::SaveFileHandleReaderWriter::LoadHandle
+98295,0x141270710,0x1412908A0,3,RE::SaveFileHandleReaderWriter::SaveHandle
 98893,0x141291c30,0x1412ca540,3,RE::BSShaderProperty::SetFlags
 98897,0x141291d40,0x1412ca650,3,RE::BSShaderProperty::SetMaterial
 99868,0x1412c5ca0,0x141304090,3,RE::NiAVObject::SetRefraction
@@ -7955,6 +7979,7 @@ id,sse,vr,status,name
 514286,0x141ec0a78,0x141f85100,3,RE::Offset::InterfaceStrings::Singleton
 514287,0x141ec0a80,0x141f85108,3,RE::Offset::Calendar::Singleton
 514290,0x141ec0a98,0x141f85120,3,RE::Offset::TESWaterSystem::GetSingleton
+514292,0x141ec0aa8,0x141f85130,3,RE::BGSGrassManager::GetSingleton
 514315,0x141ec3b78,0x141f889d8,3,RE::Offset::SkyrimVM::Singleton
 514316,0x141ec3b80,0x141f889e0,3,RE::Offset::BGSStoryTeller::Singleton
 514349,0x141ec3cb3,0x141ec3cb3,2,RE::Offset::FormFactory::FormFactoriesInitialized
@@ -7964,6 +7989,7 @@ id,sse,vr,status,name
 514360,0x141ec4150,0x141f88fb0,2,RE::TESForm::allFormsMapLock
 514361,0x141ec4158,0x141f88fb8,2,RE::TESForm::allFormsEditorIDMapLock
 514414,0x141ec4320,0x141f89188,3,RE::Offset::BGSDecalManager::GetSingleton
+514415,0x141ec4328,0x141f89190,3,RE::bhkCollisionFilter::Singleton
 514417,0x141ec4338,0x141f891a0,3,RE::NiRTTI_BGSDecalNode
 514462,0x141ec44b0,0x141f89358,3,RE::NiRTTI_BSAnimGroupSequence
 514478,0x141ec47c0,0x141f89660,3,RE::BSPointerHandleManager::GetHandleEntries
@@ -8026,6 +8052,7 @@ id,sse,vr,status,name
 517602,0x142f3a690,0x142fff488,3,RE::NiRTTI_BSPlayerDistanceCheckController
 517603,0x142f3a6a0,0x142fff498,3,RE::NiRTTI_BSSimpleScaleController
 518086,0x142f483f0,0x14300d6a0,3,RE::HandlerDictionary::GetSingleton?
+518706,0x142f4ad88,0x143010038,3,RE::CombatManager::Singleton
 519283,0x142f4bed4,0x143011184,3,RE::BarterMenu::GetTargetRefHandle?
 519295,0x142f4bf50,0x143011200,3,RE::BookMenu::GetTargetForm?
 519300,0x142f4bf78,0x143011228,3,RE::BookMenu::GetTargetReference?
@@ -8298,6 +8325,7 @@ id,sse,vr,status,name
 524719,0x143025ea8,0x14317e730,3,RE::NiRTTI_BSNonUniformScaleExtraData
 524721,0x143025ec0,0x14317e760,3,RE::NiRTTI_BSNiNode
 524722,0x143025ed0,0x14317e770,3,RE::NiRTTI_BSInstanceTriShape
+524907,0x143028490,0x143181700,3,RE::BSRenderManager::GetSingleton
 524998,0x14302c890,0x143186c10,3,RE::BSGraphics::State::GetSingleton?
 525039,0x14302cc68,0x143186dd8,3,RE::NiRTTI_bhkWorldObject
 525051,0x14302cca8,0x143186e18,3,RE::NiRTTI_bhkWorld


### PR DESCRIPTION
Adding a number of missing offsets. This covers all missing IDs from the CommonLibSSE NG and po3 forks. Also included is a collection of offsets that I am using so far in the development of Fully Dynamic Game Engine. CommonLib IDs were found by manual RE work and confirmed with the `sse_vr.csv` mapping (except `GetWeight` which curiously does not exist in that file). FuDGE IDs have additionally been manually tested in a running Skyrim VR environment.

This also fixes `ScaleformTranslationpp::BSScaleformMovieLoaderEx::Ctor`, which was incorrectly using `main`'s ID (most likely a mistake caused by the hook in ScaleformPP using main's ID, plus an offset inside that function where the call to `Ctor` happens). It has been fixed to refer to the ID/offset of the target function itself.