### PR TITLE
Add YesImSure missing address and ActorValueOwner::ModActorValue

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -485,6 +485,7 @@ id,sse,vr,status,name
 52655,0x140902860,0x14093cfe0,3,RE::SkyrimScript::HandlePolicy::GetHandleForObject
 52659,0x140902b00,0x14093d280,3,RE::SkyrimScript::HandlePolicy::GetObjectForHandle
 52662,0x1409032c0,0x14093da40,3,RE::SkyrimScript::HandlePolicy::ConvertHandleToString
+52933,0x140915790,0x14094FF10,3,YesImSure::
 53029,0x14091c620,0x140956da0,3,RE::Actor::HasLOS
 53144,0x1409252c0,0x14095fd10,3,RE::SkyrimVM::QueuePostRenderCall
 53209,0x14092b8e0,0x140965fe0,3,RE::SkyrimVM::DumpStacks

--- a/database.csv
+++ b/database.csv
@@ -301,6 +301,7 @@ id,sse,vr,status,name
 37510,0x140620690,0x140629440,3,RE::Actor::sub_140620690
 37513,0x140620900,0x1406296b0,3,RE::Actor::RestoreActorValue_140620900
 37516,0x140620cc0,0x140629a70,3,RE::Character::Update_RegenDelay__140620CC0
+37522,0x1406210f0,0x140629ea0,4,ActorValueOwner::ModActorValue
 37523,0x140621120,0x140629ed0,3,StaminaNPC::damageav
 37524,0x140621350,0x14062a100,4,RE::Actor::GetActorValueModifier
 37571,0x140623610,0x14062c3c0,3,RE::DragonSoulsGained::GetEventSource()


### PR DESCRIPTION
YesImSure missing address tested against YesImSure-NG: https://www.nexusmods.com/skyrimspecialedition/mods/76892

ActorValueOwner::ModActorValue tested against a fork that adds VR support for unlimited stamina, also confirmed in IDA the bits are identical (the method is only 0x1D bytes, so it was manually verified): 
https://www.nexusmods.com/skyrimspecialedition/mods/77439?tab=description
https://github.com/nightfallstorm/NoStamina-SKSE


