### PR TITLE
fix: fix Experience NG address

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -465,7 +465,7 @@ id,sse,vr,status,name
 36287,0x1405d25e0,0x1405daba0,4,RE::Actor::SetGhost
 36331,0x1405d5290,0x1405dd850,2,Actor::Resurrect
 36344,0x1405d62e0,0x1405de910,3,RE::Actor::GetLevel
-36345,0x1405d6300,0x1405D6300,3,Actor::DamageHealth
+36345,0x1405d6300,0x1405de930,3,Actor::DamageHealth
 36346,0x1405d6490,0x1405deac0,3,RE::GameEventHandler::FallLongDistance::CalcDoDamage
 36347,0x1405D6500,0x1405DEB30,4,Character::GetAVPercent
 36357,0x1405d6fb0,0x1405df5e0,3,FEC::UpdateAVs


### PR DESCRIPTION
The VR address was accidentally copy pasted without double checking. I double checked this address against VR's exe and confirm this is the right address. This fixes the crash users see in Experience NG