### PR TITLE
feat: add Container Distribution Framework addresses

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -208,6 +208,7 @@ id,sse,vr,status,name
 18711,0x140271be0,0x140283200,3,TESObjectCELL::sub_140271BE0
 18755,0x140273ED0,0x1402854C0,4,"void CallsMapMarkerData (int64 a1, int64 **a2)"
 18843,0x140278920,0x140289f20,4,TESObjectREFR::HandleReferenceReset
+19105,0x1402850e0,0x140296810,3,void TESObjectREFR::InitializeAfterAllFormsAreReadFromFile
 19119,0x1402866d0,0x140297e00,4,void TESObjectREFR::UpdateSoundCallBack_1402866D0 (Character * a_this)
 19142,0x1402896f0,0x14029ae20,4,"ObjectRefHandle TESObjectREFR::CreateReference(ObjectRefHandle& a_handleOut, FormType a_formType, bool a_addActorToProcessList)"
 19201,0x14028b940,0x14029d070,3,bool TESObjectREFR::HasQuestObject()
@@ -230,6 +231,7 @@ id,sse,vr,status,name
 19354,0x1402961f0,0x1402a78f0,3,RE::TESObjectREFR::GetDisplayFullName
 19369,0x140296c00,0x1402a8300,4,"bool TESObjectREFR::ActivateRef(TESObjectREFR* a_activator, uint8_t a_arg2, TESBoundObject* a_object, int32_t a_count, bool a_defaultProcessingOnly)"
 19373,0x140298190,0x1402a9890,4,void TESObjectREFR::Enable(bool a_resetInventory)
+19375,0x140298c80,0x1402aa380,3,void TESObjectREFR::ResetInventory_140298C80(TESObjectREFR * param_1)
 19385,0x1402994f0,0x1402aabf0,3,BGSLocation* TESObjectREFR::GetCurrentLocation()
 19396,0x140299a80,0x1402ab180,4,"float TESObjectREFR::GetDistance(TESObjectREFR* a_other, bool a_disabledRefs, bool a_ignoreWorldspace)"
 19400,0x14029a330,0x1402aba40,3,bool TESObjectREFR::IsCrimeToActivate()
@@ -301,6 +303,7 @@ id,sse,vr,status,name
 24469,0x140370020,0x14037F9C0,4,DynamicStringDistributor::
 24472,0x140370290,0x14037fc30,3,TESQuest::CompleteQuest
 24481,0x140370910,0x1403802b0,3,RE::TESQuest::EnsureQuestStarted
+24483,0x140370b20,0x1403804c0,3,RE::TESQuest::sub_140370B20(TESQuest *param_1)
 24486,0x140370e90,0x140380830,3,RE::TESQuest::ResetQuest
 24526,0x140375af0,0x1403854a0,3,BGSLocation::TryToClear
 24537,0x140378760,0x140388110,3,RE::TESQuest::CreateRefHandleByAliasID
@@ -347,6 +350,7 @@ id,sse,vr,status,name
 26009,0x1403c66a0,0x1403d5f20,4,RE::random
 26258,0x1403D2970,0x1403E22E0,4,WhosWho::GetFaceRelatedData
 26259,0x1403d2a60,0x1403e23d0,3,"void BSFaceGenManager::PrepareHeadPartForShaders(BSFaceGenNiNode* a_node, BGSHeadPart* a_headPart, TESNPC* a_npc)"
+26570,0x1403e1450,0x1403f0e00,3,GetActorValueIdFromName_1403E1450 (1403e144d+3)
 26574,0x1403e1790,0x1403F1140,3,void RE::ActorValueList::InitActorValueInfo()
 26592,0x1403e48d0,0x1403f4420,4,"BGSSkillPerkTreeNode * BGSSkillPerkTreeNode::ctor_1403e48d0 (BGSSkillPerkTreeNode * a_this, int32_t a_index, ActorValueInfo * a_avInfo)"
 26616,0x1403e5250,0x1403f4da0,4,RE::ActorValueOwner::GetClampedActorValue


### PR DESCRIPTION

Container Distribution Framework has been requested in discussions [here](https://github.com/alandtse/skyrim_vr_address_library/discussions/74)

I used the addresses identified from the SSE port and used ghidra to verify vr addresses from provided csvs. I wasn't able to fully match some of the methods without a more complete exe so I left confidence at 3. But playing with COIN enabled, the framework appeared to function without issues