### PR TITLE
Add SPID update addresses

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -283,6 +283,7 @@ id,sse,vr,status,name
 21435,0x1402e9c50,0x1402fb150,4,void Script::SetProcessScripts(bool a_ProcessScripts)
 21436,0x1402e9c60,0x1402fb160,4,bool Script::GetProcessScripts()
 21523,0x1402f1180,0x140302680,4,"bool GameFunc__handler::RemoveAllItems_1402F1180 (Script * param_1, longlong * param_2, TESObjectREFR * a_reference, TESObjectREFR * a_target, Script * param_5, ScriptLocals * param_6, undefined8 param_7, uint32_t param_8)"
+21556,0x1402f3040,0x140304580,3,GameFunc__handler::ResetReference
 21887,0x140300210,0x140311710,2,Console::UpdateLevel
 21951,0x140302730,0x140313C30,3,GameFunc__handler::ShowQuestObjectives
 22289,0x14030f9a0,0x140320eb0,3,"ModelReferenceEffect* TESObjectREFR::InstantiateHitArt(BGSArtObject* a_art, float a_dur, TESObjectREFR* a_facingRef, bool a_faceTarget, bool a_attachToCamera, NiAVObject* a_attachNode, bool a_interfaceEffect)"
@@ -975,6 +976,7 @@ id,sse,vr,status,name
 52730,0x140906fe0,0x140941760,3,SkyrimScript__ObjectBindPolicy::
 52767,0x140909f30,0x1409446b0,3,PapyrusTweaks::
 52933,0x140915790,0x14094ff10,3,YesImSure::
+53024,0x14091A490,0x140954C10,4,WritePapyrusLog
 53029,0x14091c620,0x140956da0,3,"bool Actor::HasLineOfSight(TESObjectREFR* a_ref, bool& a_arg2)"
 53108,0x1409204a0,0x14095aba0,3,SkyrimVM::SkyrimVM
 53115,0x140921f10,0x14095c670,2,"SkyrimVM::ProcessRegisteredUpdates(SkyrimVM* a_vm, float a_budget)"


### PR DESCRIPTION
These are needed for the latest update to SPID.

For SPID, updating the commonlibVR submodule enables compilation with upstream but an offset on a separate address is incorrect. I made a discussion [here](https://github.com/alandtse/skyrim_vr_address_library/discussions/88) on supporting this.