### PR TITLE
fix: swap to second id for GetHandleValidatedSmartPointer

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -50,7 +50,7 @@ id,sse,vr,status,name
 12626,0x14013c740,0x14014d130,3,"char* ExtraTextDisplayData::GetDisplayName(TESBoundObject* a_baseObject, float a_temperFactor)"
 12633,0x14013cc20,0x14014d610,3,ExtraTextDisplayData::sub_14013CC20
 12784,0x1401424f0,0x140152ee0,3,"bhkRigidBody* bhkCollisionObject::GetRigidBody()"
-12785,0x140142550,0x14054ed90,4,"bool GetHandleValidatedSmartPointer (undefined8 * a_refHandle, undefined8 * a_out)"
+12785,0x140142550,0x140152f40,4,"bool GetHandleValidatedSmartPointer (undefined8 * a_refHandle, undefined8 * a_out)"
 12910,0x140147bb0,0x1401585e0,3,SeasonsofSkyrim::FormSwap::model_loader_queue_ref
 13054,0x14014dc60,0x14015e690,3,RE::INISettingCollection::InsertSetting
 13113,0x14014f700,0x140160130,3,RE::INISettingCollection::Unk_09


### PR DESCRIPTION
## Summary

id `12785` (`GetHandleValidatedSmartPointer`) mapped to VR `0x14054ed90`, which is a **duplicate copy** of the function (10 call sites). The canonical VR implementation is at **`0x140152f40`** (300 call sites).

```diff
-12785,0x140142550,0x14054ed90,4,"bool GetHandleValidatedSmartPointer ..."
+12785,0x140142550,0x140152f40,4,"bool GetHandleValidatedSmartPointer ..."
```

## Evidence

| Check | `0x140152f40` (new) | `0x14054ed90` (old) |
|---|---|---|
| Call sites in VR binary | **300** | 10 |
| `addrlib.csv` record | ✓ `vr=0x140152f40, sse=0x140142550, id=12785` | — |
| Positional match to SE | ✓ neighbor 12784 → `0x140152ee0`, `+0x60` → `0x140152f40` (mirrors SE `0x1401424f0`/`0x140142550`) | far outlier |

## Ghidra verification

SE `0x140142550` and VR `0x140152f40` are **identical across all 92 instructions**. The only difference in the entire 300-byte function is the bound-handle-manager global referenced by the `LEA` at +0x2f (SE `0x141ec47c0` vs VR `0x141f89660`) — an expected `.data` relocation. Both VR copies (`0x140152f40` and `0x14054ed90`) are themselves byte-equivalent; this PR selects the canonical one.

## Context

Surfaced via alandtse/CommonLibVR#164, where CommonLibVR-NG's `GetHandleValidatedSmartPointer` uses `RELOCATION_ID(12785, 12922)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)