### PR TITLE
docs: fix BSShadowDirectionalLight functions

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1868,7 +1868,7 @@
 100781,0x141302780,0x1412f3a90,4,void BSCubeMapCamera::Dtor()
 100817,0x141304da0,0x14134b960,3,"static void BSShadowDirectionalLight::SetupFocusShadowMaps(RE::BSShadowLight* light, RE::NiCamera* camera)"
 100818,0x141305240,0x14134be20,3,"BSShadowLight::AccumulateShadowMap"
-100819,0x1413054c0,0x14134c220,4,static void BSShadowLight::Accumulate(RE::BSShadowLight* light)
+100819,0x1413054c0,0x14134c220,4,static void BSShadowDirectionalLight::SetupFocusShadowAccumulators(RE::BSShadowLight* light)
 100820,0x141305610,0x14134c370,3,"void BSShadowParabolicLight::RenderCascade(BSShadowLight::ShadowmapDescriptor* a_desc, std::uint32_t& a_index, std::uint32_t a_flags)"
 100840,0x141306240,0x141347320,4,"void BSShaderAccumulator::RenderPersistentPassList (longlong * * passList, uint32_t renderFlags)"
 100847,0x141307160,0x141348390,3,Skyrim-Upscaler

--- a/database.csv
+++ b/database.csv
@@ -1866,7 +1866,7 @@
 100771,0x1413014c0,0x141343d40,3,"bool BSDistantTreeShader::Func2_1413014C0 (BSDistantTreeShader * a_this, undefined8 param_2)"
 100781,0x141302780,0x1412f3a90,1,"void BSCubeMapCamera::Dtor()"
 100781,0x141302780,0x1412f3a90,4,void BSCubeMapCamera::Dtor()
-100817,0x141304da0,0x14134b960,3,"static void BSShadowDirectionalLight::Set(RE::BSShadowLight* light, RE::NiCamera* camera)"
+100817,0x141304da0,0x14134b960,3,"static void BSShadowDirectionalLight::SetupFocusShadowMaps(RE::BSShadowLight* light, RE::NiCamera* camera)"
 100818,0x141305240,0x14134be20,3,"BSShadowLight::AccumulateShadowMap"
 100819,0x1413054c0,0x14134c220,4,static void BSShadowLight::Accumulate(RE::BSShadowLight* light)
 100820,0x141305610,0x14134c370,3,"void BSShadowParabolicLight::RenderCascade(BSShadowLight::ShadowmapDescriptor* a_desc, std::uint32_t& a_index, std::uint32_t a_flags)"


### PR DESCRIPTION
## What

Correct the `name` column for two `BSShadowDirectionalLight` focus-shadow functions (name column only — id/addresses/status unchanged, so address resolution is unaffected; documentation fix):

| id | was | now |
|---|---|---|
| 100817 | `BSShadowDirectionalLight::Set` (incomplete) | `BSShadowDirectionalLight::SetupFocusShadowMaps` |
| 100819 | `BSShadowLight::Accumulate` (wrong class + verb) | `BSShadowDirectionalLight::SetupFocusShadowAccumulators` |

## Why

Both verified by Ghidra decompile and named consistently across the SE/AE/VR Ghidra databases:

- **100817** (SE @ `0x141304da0`): gated on `FocusShadowActors_size`, populates the per-actor `focusShadowmapDescriptors` (camera/descriptor setup).
- **100819** (SE @ `0x1413054c0`): loops `FocusShadowActors` and lazily allocates + registers a per-actor `BSShaderAccumulator`. `this` is `BSShadowDirectionalLight*`, not base `BSShadowLight`, and it sets up accumulators rather than accumulating.
