### PR TITLE
docs: correct AIProcess::SetupSpecialIdle name

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1,4 +1,4 @@
-ï»¿id,sse,vr,status,name
+﻿id,sse,vr,status,name
 10207,0x1400eb2d0,0x1400fc720,4,void SetFocusShadowDisplay1()
 10209,0x1400eb2f0,0x1400fc740,4,void SetFocusShadowDisplay2()
 10827,0x1400f6e80,0x140107430,3,RE::TESForm::GetFormEditorID

--- a/database.csv
+++ b/database.csv
@@ -1,4 +1,4 @@
-﻿id,sse,vr,status,name
+ï»¿id,sse,vr,status,name
 10207,0x1400eb2d0,0x1400fc720,4,void SetFocusShadowDisplay1()
 10209,0x1400eb2f0,0x1400fc740,4,void SetFocusShadowDisplay2()
 10827,0x1400f6e80,0x140107430,3,RE::TESForm::GetFormEditorID
@@ -856,7 +856,7 @@
 38141,0x140640f80,0x14064a2b0,4,void Job_Update_grass_140640F80 (void)
 38158,0x140642f50,0x14064c2a0,4,void AIProcess::ComputeLastTimeProcessed()
 38198,0x140644600,0x14064d950,4,"void AIProcess::AddToProcedureIndexRunning(Actor* a_actor, std::uint32_t a_num)"
-38290,0x14064b140,0x140654490,4,RE::ActorProcess::PlayIdle
+38290,0x14064b140,0x140654490,4,"bool AIProcess::SetupSpecialIdle(Actor* a_actor, DEFAULT_OBJECT a_object, TESIdleForm* a_idle, bool a_unk, bool a_unk2, TESObjectREFR* a_unk5)"
 38291,0x14064b570,0x1406548c0,4,"void AIProcess::StopCurrentIdle(Actor* a_actor, bool a_forceIdleStop)"
 38308,0x14064cb30,0x140655e80,4,void AIProcess::RandomlyPlaySpecialIdles(Actor* a_actor)
 38311,0x14064cdf0,0x140656140,4,"void AIProcess::SetActorsDetectionEvent(Actor* a_actor, const NiPoint3& a_location, std::int32_t a_soundLevel, TESObjectREFR* a_ref)"


### PR DESCRIPTION
Corrects id 38290 name from `RE::ActorProcess::PlayIdle` (wrong class, wrong name, wrong format) to the full verified signature from Ghidra SE analysis.

Confirmed via crash log analysis (2026-06-27) — CrashLogger independently labeled frame 5 as `AIProcess::SetupSpecialIdle`, and Ghidra SE decompiler confirms the full signature.

Also removes the `RE::` prefix per naming rules.