### PR TITLE
feat: add VATS internal-method address ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -979,6 +979,10 @@
 43013,0x1407521f0,0x14077d510,4,ProjectileImpact
 43022,0x1407531c0,0x14077e4e0,2,papyrus_extender::events::game::weaponhit::projectile::target_0x38d
 43030,0x140754820,0x14077fbd0,3,po3tweaks::ProjectileRange::UpdateCombatThreat
+43087,0x1407570f0,0x1407822f0,3,"void VATS::SetMode(std::uint32_t a_mode)"
+43090,0x140757960,0x140782cf0,4,void VATS::QueueCommand()
+43094,0x140757dd0,0x140783160,4,"void VATS::AdvanceCommand(bool a_arg1, bool a_last, bool a_arg3)"
+43098,0x1407581f0,0x140783580,3,"void VATS::UpdateKillCam(PlayerCharacter* a_player, void* a_arg2, std::uint32_t* a_arg3)"
 43103,0x140759360,0x1407846b0,3,"void VATS::SetMagicTimeSlowdown(float a_magicTimeSlowdown, float a_playerMagicTimeSlowdown)"
 43162,0x14075c760,0x140787AB0,3,CombatProjectileAimController::Update
 43235,0x14075fd20,0x14078b070,4,"CombatAnimation* CombatAnimation::Ctor0(Actor* a_actor, ANIM a_anim)"


### PR DESCRIPTION
## What

Adds address-library ids for four `VATS` state-machine methods found while reverse-engineering the kill-cam subsystem — discovered tangentially during a `BSTimer` RE pass (CommonLibVR [PR #203](https://github.com/alandtse/CommonLibVR/pull/203)), since `VATS::SetMode` calls `BSTimer::SetGlobalTimeMultiplier`.

| id | name | status |
|---|---|---|
| 43087 | `VATS::SetMode(std::uint32_t a_mode)` | 3 |
| 43090 | `VATS::QueueCommand()` | 4 |
| 43094 | `VATS::AdvanceCommand(bool, bool, bool)` | 3 |
| 43098 | `VATS::UpdateKillCam(PlayerCharacter*, void*, std::uint32_t*)` | 3 |

## Verification

Decompiled and cross-checked on SE 1.5.97 and VR 1.4.15 (offsets, field accesses, and call graph — `SetMode` performs the enter/exit side effects and sets `VATS.mode`; `QueueCommand` allocates a `VATSCommand` and calls `SetMode(kKillCam)`; `AdvanceCommand` pops the queue or fully clears it; `UpdateKillCam` is gated to `mode == kKillCam` and drives the per-frame camera/HUD/timer state).

`QueueCommand` and `AdvanceCommand` are **byte-identical** between SE and VR — full mnemonic-sequence match, not just equivalent decompiled logic — hence status 4. `SetMode` and `UpdateKillCam` are verified-equivalent by decompile but the VR compiler generated structurally different code (separate calls for refcount releases SE inlined; differing instruction counts), so status 3 per the README's definition ("may differ structurally").

`RE::VATS`'s struct layout (`include/RE/V/VATS.h` in CommonLibVR) was already fully named from prior work; these four methods were the only unbound orchestration entry points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)