### PR TITLE
feat: add SkyrimVM::Freeze address id

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1382,6 +1382,7 @@
 53116,0x140922a90,0x14095d1f0,4,"SkyrimVM::ProcessTasklets(SkyrimVM* a_vm, float a_budget)"
 53144,0x1409252c0,0x14095fd10,3,RE::SkyrimVM::QueuePostRenderCall
 53195,0x14092a9c0,0x140965410,3,SkyrimVM::HandleEvent(BSScript::StatsEvent* stats)
+53204,0x14092b5e0,0x140965c90,3,void SkyrimVM::Freeze()
 53205,0x14092b6c0,0x140965d80,2,PapyrusTweaks::
 53207,0x14092b800,0x140965f00,3,"SkyrimVM::LoadGame(SkyrimVM* this, LoadStorageWrapper* a_wrapper)"
 53209,0x14092b8e0,0x140965fe0,3,RE::SkyrimVM::DumpStacks


### PR DESCRIPTION
## What

Adds id 53204 for `SkyrimVM::Freeze` — found while tracing `BGSSaveLoadManager`'s save/load reset call graph. Spins `ProcessRegisteredUpdates` until `isFrozen()` returns true or a timeout elapses.

## Verification

Identified via a literal debug string: `"error: VM timed out while waiting to freeze! Save will be bad."` — logged if the timeout fires. Located on AE and VR via proximity to the existing `QueuePostRenderCall`/`RelayEvent` anchors in the same cluster (`53144`/`53221`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)