### PR TITLE
feat: add TESObjectREFR::GetRotationMatrix id

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -298,6 +298,7 @@
 19316,0x1402943b0,0x1402a5ac0,4,bool Actor::Update3D()
 19322,0x1402944F0,0x1402A5C00,3,TESModel* TESObjectREFR::GetSkeletonModel(TESObjectREFR* a_this)
 19323,0x1402945e0,0x1402a5cf0,3,RE::TESObjectREFR::FindReferenceFor3D
+19325,0x1402946d0,0x1402a5dd0,3,"NiMatrix3* TESObjectREFR::GetRotationMatrix(NiMatrix3* a_out)"
 19326,0x140294730,0x1402a5e30,3,void TESObjectREFR::GetTransform(NiTransform& a_transform)
 19338,0x140295060,0x1402a6760,3,bool Actor::IsLimbGone(std::uint32_t a_limb)
 19354,0x1402961f0,0x1402a78f0,3,RE::TESObjectREFR::GetDisplayFullName


### PR DESCRIPTION
## What

Adds id 19325 for \`TESObjectREFR::GetRotationMatrix(NiMatrix3* a_out)\` — found via reuse-count triage rather than a single call site. This function is called from **27 distinct functions** across the binary (\`BGSCameraShot::SetLocationNode\`/\`Play\`, \`CheckAttack\`, \`Rotate\`, \`SetRotation\`, \`MoveToInteractionLocation\`, and more), making it one of the more load-bearing unnamed \`TESObjectREFR\` internals.

## Also resolved (no new id needed)

Its callee at SE \`0x140c544e0\` was mis-attributed to \`TESObjectREFR::\` by auto-analysis — the first parameter was force-typed as \`this\`, but it's actually a raw \`NiMatrix3*\` out-buffer. It's the same euler-angle-to-matrix math already reimplemented in CommonLibVR as \`NiMatrix3::SetEulerAnglesXYZ(float, float, float)\`, so no separate address binding is needed.

## Verification

Decompiled on SE, cross-checked on AE and VR via the neighboring \`TESObjectREFR::SetAngle\`/\`FindReferenceFor3D\` anchors already in this database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)