### PR TITLE
feat: add console SaveGame command handler

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -363,6 +363,7 @@
 22339,0x140310e60,0x140322370,3,po3tweaks::NoCheatMode::GodMode
 22340,0x140310ec0,0x140322370,3,po3tweaks::NoCheatMode::ImmortalMode
 22350,0x140311250,0x140322760,3,powerof3tweaks::ToggleCollisionFix::ToggleCollision
+22465,0x140316e60,0x140328370,3,Cmd_SaveGame_Execute
 22790,0x140324e90,0x1402af140,4,BGSStoryEventManager* BGSStoryEvent::BGSStoryEventManager::GetSingleton() include\RE\B/BGSStoryEventManager.h:20
 22825,0x140325f00,0x140335740,4,void * SKSE::CreateUIMessageData_140325f00 (BSFixedString * param_1)
 22843,0x140326460,0x140335ca0,3,RE::MessageDataFactoryManager::GetSingleton


### PR DESCRIPTION
Adds SE id 22465 -> VR 0x140328370 (status 3) for the console SaveGame command handler (Cmd_SaveGame_Execute). Verified in Ghidra on both binaries: identical structure (can-save check, flag build, BGSSaveLoadManager::Save call at handler+0xC4 in SE 1.5.97, AE 1.6.1170, and VR). Needed by EngineFixes' console-save-deadlock fix (alandtse/EngineFixesSkyrim64#26) so VR resolves via RELOCATION_ID instead of a raw offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EEz3ZzFwhSRdd7q3UujymD