### PR TITLE
feat: register BGSAcousticSpace::Deactivate id

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -624,6 +624,7 @@
 34256,0x140566a90,0x14056CFD0,3,TelekinesisEffect::Func21(TelekinesisEffect *a1)
 34259,0x140566bd0,0x14056D0B0,3,TelekinesisEffect::Func20(TelekinesisEffect* a1)
 34260,0x140566c50,0x14056D180,3,"TelekinesisEffect::Func4(TelekinesisEffect *a1, float a2)"
+34309,0x1405693b0,0x14056f9a0,2,void BGSAcousticSpace::Deactivate()
 34413,0x14056c9d0,0x140572fd0,3,"DialogueItem* DialogueItem::Ctor(TESQuest* a_quest, TESTopic* a_topic, TESTopicInfo* a_topicInfo, Actor* a_speaker)"
 34429,0x14056D570,0x140573B70,4,"void DialogueSubtitleStrings (char **a1, TESTopic *a2, TESTopicInfo *a3, Character *a4, void *a5)"
 34434,0x14056DA60,0x140574060,4,"void DialogueMenuStrings (void *a1, TESQuest *a2, TESTopic *a3, TESTopicInfo *a4, TESObjectREFR *a5, void *a6)"


### PR DESCRIPTION
## Summary
- Registers `BGSAcousticSpace::Deactivate` (id 34309) so it can be exposed as a dev-facing method in CommonLibVR via `RELOCATION_ID(34309, 35131)`.
- Manages the global "current acoustic space" state when switching away from an acoustic space (audio crossfade + reverb transition).

## Verification
- Confirmed via Ghidra decompile in SE, AE, and VR -- same logic/behavior in each.
- Status 2 (manually entered, assumed verified): behavior confirmed identical across runtimes, not independently byte-verified in VR.