### PR TITLE
feat: register IOManager singleton and core methods

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1675,6 +1675,10 @@
 72790,0x140d02aa0,0x140d495f0,3,"void NiParticleSystem::CopyMembersFrom(NiParticleSystem* a_src, NiParticleSystem* a_dst, NiCloningProcess& a_cloning)"
 72799,0x140d03330,0x140d49ec0,4,void NiParticleSystem::AddModifier(NiPSysModifier* a_modifier)
 73882,0x140d28c40,0x140d70310,3,"Setting * SettingT<T1>::SetStringValue_140D28C40 (Setting * a_this, char * a_string)"
+73897,0x140d29580,0x140d714a0,3,"void IOManager::NotifyTaskComplete(RE::BSTask* a_task)"
+73967,0x140d2cb30,0x140d74ed0,3,IOManager::IOManager()
+73968,0x140d2cc50,0x140d74ff0,3,IOManager::~IOManager()
+73970,0x140d2cec0,0x140d75270,3,"void IOManager::ResubmitTask(RE::BSTask* a_task)"
 74040,0x140d2f220,0x140d775e0,4,"BSResource::ErrorCode BSModelDB::Demand(const char* a_modelPath, NiPointer<NiNode>& a_modelOut, const DBTraits::ArgsType& a_args)"
 74236,0x140d38120,0x140d805b0,3,RE::INISettingCollection::WriteSetting
 74237,0x140d38310,0x14053c550,3,RE::INISettingCollection::ReadSetting
@@ -9813,6 +9817,7 @@
 524537,0x143015438,0x14316dc38,3,RE::NiRTTI_NiPSysFieldModifier
 524538,0x143015448,0x14316dc48,3,RE::NiRTTI_NiPSysModifierBoolCtlr
 524539,0x143015458,0x14316dc58,3,RE::NiRTTI_NiPSysCollider
+524542,0x143015478,0x14316dcf0,3,IOManager::singleton
 524551,0x14301d708,0x143175f88,3,RE::NiRTTI_BSMultiBound
 524552,0x14301d718,0x143175f98,3,RE::NiRTTI_BSMultiBoundRoom
 524554,0x14301d730,0x143175fb0,3,RE::NiRTTI_BSMultiBoundAABB

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -7153,6 +7153,10 @@ sseid,aeid,confidence,name
 69447,70824,3,RE::NiTimeController::ComputeScaledTime
 69449,70826,3,RE::NiTimeController::ProcessClone
 69564,70948,3,RE::BSDynamicTriShape::BSDynamicTriShape
+73897,75634,3,IOManager::NotifyTaskComplete
+73967,75703,3,IOManager::IOManager
+73968,75704,3,IOManager::~IOManager
+73970,75706,3,IOManager::ResubmitTask
 75507,77299,3,RE::RendererData::CreateRenderTexture
 76170,77998,3,RE::NiAVObject::SetCollisionLayer
 76171,77999,3,RE::NiAVObject::UpdateRigidBodySettings
@@ -19285,7 +19289,7 @@ sseid,aeid,confidence,name
 524539,411118,3,RE::NiRTTI_NiPSysCollider
 524540,411119,1,
 524541,411120,1,
-524542,411121,1,
+524542,411121,3,IOManager::singleton
 524543,411122,1,
 524544,411123,1,
 524545,411124,1,


### PR DESCRIPTION
Registers address-library ids discovered while RE-ing the `BSTask` -> `IOTask` -> `QueuedFile` -> `BSQueuedResourceCollectionBase` cluster's follow-on: the global `IOManager` singleton.

- `524542` - `IOManager::singleton`, the global `IOManager*` data pointer (confirmed independently constructed/written in SE/AE/VR's `TES::Ctor`-equivalent; no wrapper `GetSingleton()` exists, code reads the raw pointer directly, 137+ call sites in SE alone).
- `73967`/`73968` - `IOManager::IOManager()`/`~IOManager()`.
- `73897` - `IOManager::NotifyTaskComplete(RE::BSTask*)`, non-virtual, called directly by `BSQueuedResourceCollectionBase::Unk_11`.
- `73970` - `IOManager::ResubmitTask(RE::BSTask*)`, IOManager's own vtable slot 17 (offset 0x88), called by `BSQueuedResourceCollectionBase::Unk_09` via `singleton->vftable->Func17_88(singleton, task)`.

All four cross-checked in SE, AE (via independent construction/callsite discovery, not id arithmetic), and VR (via RTTI/VTABLE offsets already present in CommonLibVR's `Offsets_RTTI.h`/`Offsets_VTABLE.h`). `se_ae.csv` rows added/updated to match.