### PR TITLE
chore: set conventional-commit message for pre-commit.ci autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,6 @@ repos:
     rev: v1.7.12
     hooks:
       - id: actionlint
+
+ci:
+  autoupdate_commit_msg: "chore(deps): pre-commit autoupdate"


### PR DESCRIPTION
## Summary
- pre-commit.ci's default autoupdate commit subject ("[pre-commit.ci] pre-commit autoupdate") isn't conventional-commit-formatted and doesn't parse correctly against this repo's semantic-release config
- Adds `ci.autoupdate_commit_msg` in `.pre-commit-config.yaml` so future autoupdate PRs generate a proper `chore(deps): ...` subject

## Test plan
- [x] N/A — config-only change, takes effect on the next pre-commit.ci autoupdate run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pre-commit maintenance configuration to use a standardized update commit message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->