### PR TITLE
fix: correct VR/AE addresses for HUDMenu/Compass ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1301,6 +1301,7 @@
 50674,0x14087aba0,0x1408A6910,3,DescriptionFramework::
 50680,0x14087b1e0,0x1408a6f50,4,"void GiftMenu::OpenMenu_Impl(Actor* a_gifter, Actor* a_receiver, BSTSmartPointer<IGiftMenuScriptCallback>* a_callbackFn, BGSListForm* a_filterList, bool a_showStolenItems, bool a_useFavorPoints)"
 50688,0x14087ba70,0x1408a77e0,3,EssentialFavorites::Gifting::IsQuestObject
+50718,0x14087d580,0x1408aa8b0,4,"UI_MESSAGE_RESULTS HUDMenu::ProcessMessage(RE::UIMessage& a_message)"
 50725,0x14087f070,0x1408ac880,4,void SendHUDMessage::PushHUDMode(const char* a_hudMode)
 50726,0x14087f080,0x1408ac890,4,void SendHUDMessage::PopHUDMode(const char* a_hudMode)
 50727,0x14087F090,0x1408AC8A0,3,"void UpdateCrosshairCaveLeaving(bool a_valid, const char *a2)"
@@ -1312,6 +1313,7 @@
 50757,0x1408808d0,0x1408ae1e0,3,HUDNotifications::Update
 50758,0x140880fd0,0x1408ae8e0,3,undefined8 ProcessMessage_140880FD0 (HUDNotifications * a_this)
 50771,0x140881cc0,0x1408af5c0,3,TrueHUD::HUDChargeMeter::Update_140881CC0
+50773,0x140882070,0x1408af970,4,void Compass::Update()
 50776,0x140882520,0x1408afe70,3,EnemyHealth::Update
 50881,0x140887600,0x1408b4b40,3,"void Inventory3DManager::Begin3D (Inventory3DManager * a_this, INTERFACE_LIGHT_SCHEME a_scheme)"
 50882,0x140887750,0x1408b4c90,3,std::uint32_t Inventory3DManager::Render()

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -6483,6 +6483,7 @@ sseid,aeid,confidence,name
 50653,51547,1,
 50655,51549,1,
 50657,51554,1,
+50718,51612,4,RE::HUDMenu::ProcessMessage
 50749,51644,1,BSTEventSink_BSRemoteGamepadEvent_::Handle_*
 50750,51645,1,HUDObject::RegisterHUDComponent_*
 50751,51646,1,
@@ -6495,7 +6496,7 @@ sseid,aeid,confidence,name
 50763,51658,1,HUDMeter::ProcessMessage_*
 50764,51659,1,
 50766,51661,1,ActorValueMeter::ProcessMessage_*
-50773,51668,1,Compass::Update_*
+50773,51668,4,RE::Compass::Update
 50776,51671,1,EnemyHealth::Update_*
 50782,51677,1,FloatingQuestMarker::sub_*
 50783,51678,1,FloatingQuestMarker::RegisterHUDComponent_*


### PR DESCRIPTION
## Summary
Follow-up to #161 / issue #13. Two ids couldn't be confirmed there because the community auto-matcher CSVs the reporter used placed their VR addresses far from the real functions:
- `50718` (`HUDMenu::ProcessMessage`) had no reliable VR candidate at all
- `50773` (`Compass::Update`) had a VR candidate the reporter themselves flagged as wrong (9.6MB off)

Both `HUDMenu` and `Compass` already have their vtables registered in CommonLibVR (`VTABLE_HUDMenu`, `VTABLE_Compass`), so instead of another auto-matcher guess, the real VR/AE addresses were read directly out of each runtime's compiled vtable at the known slot (`HUDMenu` slot 4, `Compass` slot 1) -- ground truth, not inference.

- `50718`: SE `0x14087d580` -> VR `0x1408aa8b0` (also found the real AE address, `0x14091ce90`; not previously registered anywhere)
- `50773`: SE `0x140882070` -> VR `0x1408af970` (previously-proposed VR address confirmed wrong, matching the reporter's own rejection). AE `0x1409222c0` matches the AE id (51668) already on file in `se_ae.csv` at confidence 1 -- bumped to 4 now that it's cross-validated in all three runtimes.

## Test plan
- [x] Confirmed via direct vtable-slot memory reads in Ghidra across SE/AE/VR (not address-library id arithmetic, not community CSV trust)