### PR TITLE
fix: register BSLightingShader::SetupTexture id

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1938,6 +1938,7 @@
 100540,0x1412eeb90,0x141330a40,3,"RENDER_TARGET FUN_1412eeb90 (BSImagespaceShader * * param_1, RENDER_TARGET param_2, RENDER_TARGET param_3)"
 100563,0x1412f2020,0x141338400,3,"void BSLightingShader::Func4_1412F2020 (BSLightingShader * a_this, undefined8 param_2, undefined8 param_3)"
 100565,0x1412f2bb0,0x141338f60,3,"void BSLightingShader::Func6_1412F2BB0 (BSLightingShader * a_this, undefined8 param_2, undefined8 param_3, undefined8 param_4)"
+100587,0x1412f5590,0x14133c1c0,3,"void BSLightingShader::SetupTexture(unsigned int a_slot, RE::NiPointer<RE::NiSourceTexture> const& a_texture, RE::BSLightingShaderMaterialBase * a_material)"
 100602,0x1412f63d0,0x141333470,3,"void BSWaterShader::Func4_1412F63D0 (BSWaterShader * a_this, undefined8 param_2)"
 100710,0x1412fd790,0x14133fcb0,4,BSRenderPass::Set
 100711,0x1412fd830,0x14133fd50,4,"BSRenderPass::SetLights"


### PR DESCRIPTION
Registers address-library id 100587 (SE `0x1412f5590` / VR `0x14133c1c0`), a small
pixel-shader texture/sampler-state helper called repeatedly from
`BSLightingShader::SetupMaterial`. Currently unregistered, so it has no VR
address in the generated release csv.

Verified in Ghidra: SE and VR decompiles are structurally identical, and the
patch-site bytes (`48 8b 42 48 41`, the function's first instruction) are
byte-identical between the two binaries. `addrlib.csv` already carried this
mapping as an unverified hint; this PR promotes it into `database.csv` at
status 3 (manually verified via decompile; automatic-tool hint agrees) since
downstream in the function some global-table offsets differ structurally
between SE and VR.

Needed so EngineFixesSkyrim64's upcoming null-texture-pointer crash fix
(`RELOCATION_ID(100587, ...)`) resolves correctly on VR.