### PR TITLE
feat: register LoadMovieImageCallback id (SE/AE/VR)

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -18325,3 +18325,9 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+81525,0x140f0eef0,0x140f6bbf0,3,"void* GFxValue::ObjectInterface::ResolveCharacter(void* a_data, void* a_valueData, undefined8 a_extra1, undefined8 a_flags) (tentative name; near-universal GFxValue-to-internal-character resolver shared by ~43 ObjectInterface methods in SE incl. GotoAndPlay/GetMember/SetMember/Invoke/AttachMovie/etc.; tail-calls ResolveCharacter2 id 81751)"
+81751,0x140f1f020,0x140f7bd20,3,"void* GFxValue::ObjectInterface::ResolveCharacter2(void* a_valueData, void* a_targetPath, void* a_valueData2, undefined8 a_flags) (tentative name; inner helper of ResolveCharacter id 81525; resolves via GASEnvironment::FindTarget id 81202)"
+81202,0x140efe220,0x140f5af20,3,"void* GASEnvironment::FindTarget(void* a_pathValue, char* a_path, void* a_unused, undefined8 a_flags) (tentative name matching well-known Scaleform/AS2 semantics; resolves a '/'-delimited AS target path string to a character via repeated GFxSprite::GetMovieClip calls)"
+73914,0x140d2a220,0x140d723f0,3,"void BSTaskManagerThread::Run(BSTaskManagerThread* a_this)"
+73925,0x140d2ae80,0x140d730e0,3,"BSTaskManagerThread* BSTaskManagerThread::dtor_deleting(BSTaskManagerThread* a_this)"
+81844,0x140f24c50,0x140f81950,2,"void LoadMovieImageCallback(void* a_movieRoot, void* a_loadQueueEntry, void* a_action, void* a_urlInfo) (self-named via its own error-log literal 'LoadMovieImageCallback failed to load image'; completes an AS3 MovieClip.loadMovie()-style external image/SWF load request, dispatches URLNotFound/onLoad-style events; VR match by identical literal + decompile parity, not yet byte-diffed)"

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -30130,3 +30130,9 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
+81525,83579,3,GFxValue::ObjectInterface::ResolveCharacter
+81751,83812,3,GFxValue::ObjectInterface::ResolveCharacter2
+81202,83265,3,GASEnvironment::FindTarget
+73914,75651,3,BSTaskManagerThread::Run
+73925,75666,3,BSTaskManagerThread::dtor_deleting
+81844,83916,3,LoadMovieImageCallback


### PR DESCRIPTION
## Summary
- Registers address-library id 81844 (`database.csv`) and AE mapping (`se_ae.csv`) for `LoadMovieImageCallback` -- a Scaleform GFx internal callback completing an AS3 `MovieClip.loadMovie()`-style external image/SWF load request.
- Function is self-named via its own error-log format string (`"LoadMovieImageCallback failed to load image \"%s\"\n"`), found identically in SE (0x140f24c50), AE (0x14100caf0), and VR (0x140f81950); decompiles are structurally identical across all three.
- Renamed the corresponding `FUN_*` placeholders to `LoadMovieImageCallback` in all three Ghidra programs (SE/AE/VR) with plate comments; not part of this CSV-only PR.

## Test plan
- [x] `awk -F, '$1==81844' database.csv` / `se_ae.csv` show the new rows, no duplicates
- [x] No leftover git conflict markers in either file