### PR TITLE
feat(queuedfile): register ProcessStateMachine ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -18325,3 +18325,9 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+74000,0x140d2dda0,0x140d76180,2,void QueuedFile::ProcessStateMachine()
+73999,0x140d2dd50,0x140d76130,2,void QueuedFile::BeginProcessing()
+73995,0x140d2dc90,0x140d76070,2,void QueuedFile::~QueuedFile()
+74013,0x140d2e350,0x140d76730,2,QueuedFile* QueuedFile::dtor_deleting()
+74003,0x140d2df00,0x140d762e0,2,void QueuedFile::NotifyChildrenAndFinalize(std::uint32_t a_flag)
+74005,0x140d2e090,0x140d76470,2,void QueuedFile::AddChild(BSTask* a_child)

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -30130,3 +30130,10 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
+74000,75739,3,void QueuedFile::ProcessStateMachine()
+73999,75738,3,void QueuedFile::BeginProcessing()
+73995,75734,3,void QueuedFile::~QueuedFile()
+74013,75755,3,QueuedFile* QueuedFile::dtor_deleting()
+74003,75742,3,void QueuedFile::NotifyChildrenAndFinalize(std::uint32_t a_flag)
+74005,75744,3,void QueuedFile::AddChild(BSTask* a_child)
+73996,75735,3,std::int32_t QueuedFile::GetTotalChildrenCount()


### PR DESCRIPTION
Registers ids for a QueuedFile state-machine RE pass (see companion CommonLibVR headers PR discussion): `ProcessStateMachine`, `BeginProcessing`, the real `~QueuedFile`/`dtor_deleting` pair, `NotifyChildrenAndFinalize` (the QueuedFile override of `IOTask::Unk_08`), `AddChild`, and `GetTotalChildrenCount`.

All confirmed via independent decompile-parity across SE 1.5.97 / AE 1.6.1170 / VR 1.4.15 (not id arithmetic) -- logic is identical in all three; VR fields are shifted +8 as expected from `IOTask::VR_RUNTIME_DATA`. `GetTotalChildrenCount`'s VR twin wasn't separately emitted as a function by the VR compiler (likely folded/inlined), so it's registered SE+AE only (`se_ae.csv`), not `database.csv`.