### PR TITLE
feat: register GASObjectInterface fallback ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1819,7 +1819,9 @@
 80547,0x140ed80b0,0x140f30f20,3,RE::GFxMovieView::InvokeNoReturn
 80620,0x140edbfa0,0x140f38ca0,3,RE::GFxLoader::CreateMovie
 80905,0x140ee98f0,0x140f465f0,3,GASObject::GASObjectInterface_Func4
+80915,0x140eea220,0x140f46f20,3,GASObject::GASObjectInterface_Func9
 80929,0x140eeada0,0x140f47aa0,3,SetMemberFallback
+80931,0x140eeb3b0,0x140f480b0,3,GASObject::GASObjectInterface_Func10
 82382,0x140f45350,0x140fa2050,4,bool BSScaleformImageLoader::AddTexture(BSScaleformExternalTexture& a_texture)
 82383,0x140f45820,0x140fa2520,4,void BSScaleformImageLoader::RemoveTexture(BSScaleformExternalTexture& a_texture)
 82462,0x140f48270,0x140fa4f70,3,bool GSysAllocPaged::InitHeapEngine(const void* a_heapDesc)

--- a/database.csv
+++ b/database.csv
@@ -18329,3 +18329,7 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+80930,0x140eeb340,0x140f48040,2,GASObject::SetMemberFlags
+80941,0x140eeb950,0x140f48650,2,GASObject::Unwatch
+80943,0x140eeba70,0x140f48770,2,GASObject::VisitMembers
+80944,0x140eebc80,0x140f48980,2,GASObject::Watch

--- a/database.csv
+++ b/database.csv
@@ -1821,7 +1821,11 @@
 80905,0x140ee98f0,0x140f465f0,3,GASObject::GASObjectInterface_Func4
 80915,0x140eea220,0x140f46f20,3,GASObject::GASObjectInterface_Func9
 80929,0x140eeada0,0x140f47aa0,3,SetMemberFallback
+80930,0x140eeb340,0x140f48040,2,GASObject::SetMemberFlags
 80931,0x140eeb3b0,0x140f480b0,3,GASObject::GASObjectInterface_Func10
+80941,0x140eeb950,0x140f48650,2,GASObject::Unwatch
+80943,0x140eeba70,0x140f48770,2,GASObject::VisitMembers
+80944,0x140eebc80,0x140f48980,2,GASObject::Watch
 82382,0x140f45350,0x140fa2050,4,bool BSScaleformImageLoader::AddTexture(BSScaleformExternalTexture& a_texture)
 82383,0x140f45820,0x140fa2520,4,void BSScaleformImageLoader::RemoveTexture(BSScaleformExternalTexture& a_texture)
 82462,0x140f48270,0x140fa4f70,3,bool GSysAllocPaged::InitHeapEngine(const void* a_heapDesc)
@@ -18329,7 +18333,3 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
-80930,0x140eeb340,0x140f48040,2,GASObject::SetMemberFlags
-80941,0x140eeb950,0x140f48650,2,GASObject::Unwatch
-80943,0x140eeba70,0x140f48770,2,GASObject::VisitMembers
-80944,0x140eebc80,0x140f48980,2,GASObject::Watch

--- a/database.csv
+++ b/database.csv
@@ -1818,6 +1818,8 @@
 80446,0x140ed3a50,0x140f2da40,3,GString* GString::ctor(const char* a_str)
 80547,0x140ed80b0,0x140f30f20,3,RE::GFxMovieView::InvokeNoReturn
 80620,0x140edbfa0,0x140f38ca0,3,RE::GFxLoader::CreateMovie
+80905,0x140ee98f0,0x140f465f0,3,GASObject::GASObjectInterface_Func4
+80929,0x140eeada0,0x140f47aa0,3,SetMemberFallback
 82382,0x140f45350,0x140fa2050,4,bool BSScaleformImageLoader::AddTexture(BSScaleformExternalTexture& a_texture)
 82383,0x140f45820,0x140fa2520,4,void BSScaleformImageLoader::RemoveTexture(BSScaleformExternalTexture& a_texture)
 82462,0x140f48270,0x140fa4f70,3,bool GSysAllocPaged::InitHeapEngine(const void* a_heapDesc)

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -30134,3 +30134,7 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
+80930,83030,2,GASObject::SetMemberFlags
+80941,83041,2,GASObject::Unwatch
+80943,83043,2,GASObject::VisitMembers
+80944,83044,2,GASObject::Watch

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -7165,7 +7165,9 @@ sseid,aeid,confidence,name
 80302,82325,3,RE::BSScaleformManager::LoadMovie
 80446,82562,3,RE::GString::Ctor
 80905,83005,3,GASObject::GASObjectInterface_Func4
+80915,83015,3,GASObject::GASObjectInterface_Func9
 80929,83029,3,SetMemberFallback
+80931,83031,3,GASObject::GASObjectInterface_Func10
 82462,84557,3,RE::GSysAllocPaged::InitHeapEngine
 82464,84559,3,RE::GSysAllocPaged::ShutdownHeapEngine
 85760,87840,1,

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -7167,7 +7167,11 @@ sseid,aeid,confidence,name
 80905,83005,3,GASObject::GASObjectInterface_Func4
 80915,83015,3,GASObject::GASObjectInterface_Func9
 80929,83029,3,SetMemberFallback
+80930,83030,2,GASObject::SetMemberFlags
 80931,83031,3,GASObject::GASObjectInterface_Func10
+80941,83041,2,GASObject::Unwatch
+80943,83043,2,GASObject::VisitMembers
+80944,83044,2,GASObject::Watch
 82462,84557,3,RE::GSysAllocPaged::InitHeapEngine
 82464,84559,3,RE::GSysAllocPaged::ShutdownHeapEngine
 85760,87840,1,
@@ -30134,7 +30138,3 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
-80930,83030,2,GASObject::SetMemberFlags
-80941,83041,2,GASObject::Unwatch
-80943,83043,2,GASObject::VisitMembers
-80944,83044,2,GASObject::Watch

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -7164,6 +7164,8 @@ sseid,aeid,confidence,name
 80087,82411,3,RE::BSScaleformManager::FileExists
 80302,82325,3,RE::BSScaleformManager::LoadMovie
 80446,82562,3,RE::GString::Ctor
+80905,83005,3,GASObject::GASObjectInterface_Func4
+80929,83029,3,SetMemberFallback
 82462,84557,3,RE::GSysAllocPaged::InitHeapEngine
 82464,84559,3,RE::GSysAllocPaged::ShutdownHeapEngine
 85760,87840,1,


### PR DESCRIPTION
## Summary
- Registers id 80929 (`SetMemberFallback`, SE 0x140eeada0 / AE 0x140fd2860 / VR 0x140f47aa0) — the generic AS3 property-set fallback that `SetSpecialTransformProperty` (id 84051) falls through to for non-transform property names. Confirmed structurally identical across SE/AE/VR by decompile.
- Registers id 80905 (`GASObject::GASObjectInterface_Func4`, SE 0x140ee98f0 / AE 0x140fd13c0 / VR 0x140f465f0) — propagates the name already established in AE (confirmed as the direct call target from `GetSpecialTransformProperty`'s fallback path) to SE/VR, where it was previously an unnamed `FUN_*`.
- Both entries confirmed via independent Ghidra decompile per runtime, not id-arithmetic assumption.

## Test plan
- [ ] `python vr_address_tools.py . generate` regenerates cleanly with these ids included (status 3, so included at default `--min 2`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>