### PR TITLE
feat(gfx): register GFxMovieRoot Advance ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1818,6 +1818,8 @@
 80446,0x140ed3a50,0x140f2da40,3,GString* GString::ctor(const char* a_str)
 80547,0x140ed80b0,0x140f30f20,3,RE::GFxMovieView::InvokeNoReturn
 80620,0x140edbfa0,0x140f38ca0,3,RE::GFxLoader::CreateMovie
+81705,0x140f1b370,0x140f78070,3,RE::GFxMovieRoot::Advance
+81803,0x140f20a60,0x140f7d760,3,RE::GFxMovieRoot::GotoLabeledFrame
 82382,0x140f45350,0x140fa2050,4,bool BSScaleformImageLoader::AddTexture(BSScaleformExternalTexture& a_texture)
 82383,0x140f45820,0x140fa2520,4,void BSScaleformImageLoader::RemoveTexture(BSScaleformExternalTexture& a_texture)
 82462,0x140f48270,0x140fa4f70,3,bool GSysAllocPaged::InitHeapEngine(const void* a_heapDesc)
@@ -18325,5 +18327,3 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
-81705,0x140f1b370,0x140f78070,3,RE::GFxMovieRoot::Advance
-81803,0x140f20a60,0x140f7d760,3,RE::GFxMovieRoot::GotoLabeledFrame

--- a/database.csv
+++ b/database.csv
@@ -18325,3 +18325,5 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+81705,0x140f1b370,0x140f78070,3,RE::GFxMovieRoot::Advance
+81803,0x140f20a60,0x140f7d760,3,RE::GFxMovieRoot::GotoLabeledFrame

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -7164,6 +7164,8 @@ sseid,aeid,confidence,name
 80087,82411,3,RE::BSScaleformManager::FileExists
 80302,82325,3,RE::BSScaleformManager::LoadMovie
 80446,82562,3,RE::GString::Ctor
+81705,83766,3,GFxMovieRoot::Advance
+81803,83873,3,GFxMovieRoot::GotoLabeledFrame
 82462,84557,3,RE::GSysAllocPaged::InitHeapEngine
 82464,84559,3,RE::GSysAllocPaged::ShutdownHeapEngine
 85760,87840,1,
@@ -30130,5 +30132,3 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
-81705,83766,3,GFxMovieRoot::Advance
-81803,83873,3,GFxMovieRoot::GotoLabeledFrame

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -30130,3 +30130,5 @@ sseid,aeid,confidence,name
 847305,290566,1,??_R3type_info@@8
 847306,290570,1,??_R3BSSocket@@8
 847307,290574,1,??_R3BSSocketServer@@8
+81705,83766,3,GFxMovieRoot::Advance
+81803,83873,3,GFxMovieRoot::GotoLabeledFrame


### PR DESCRIPTION
## Summary
- Registers id 81705 (SE 0x140f1b370 / VR 0x140f78070) as `RE::GFxMovieRoot::Advance`
- Registers id 81803 (SE 0x140f20a60 / VR 0x140f7d760) as `RE::GFxMovieRoot::GotoLabeledFrame`
- Both confirmed via decompile-parity across SE/AE/VR; AE already had these named (`GFxMovieRoot::Advance`/`GotoLabeledFrame`) and `se_ae.csv` now pairs the ids explicitly.
- `Advance` matches CommonLibVR's existing `RE::GFxMovieRoot::Advance` (vtable slot 25, identical signature `float(float, uint32_t)`).

## Test plan
- [ ] `python vr_address_tools.py . generate` to confirm the new ids parse and sort cleanly