### PR TITLE
fix: register BSLightingShaderMaterialLandscape helper id

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1938,6 +1938,7 @@
 100540,0x1412eeb90,0x141330a40,3,"RENDER_TARGET FUN_1412eeb90 (BSImagespaceShader * * param_1, RENDER_TARGET param_2, RENDER_TARGET param_3)"
 100563,0x1412f2020,0x141338400,3,"void BSLightingShader::Func4_1412F2020 (BSLightingShader * a_this, undefined8 param_2, undefined8 param_3)"
 100565,0x1412f2bb0,0x141338f60,3,"void BSLightingShader::Func6_1412F2BB0 (BSLightingShader * a_this, undefined8 param_2, undefined8 param_3, undefined8 param_4)"
+100588,0x1412f5630,0x14133c260,3,"void BSLightingShaderMaterialLandscape::sub_1412F5630 (BSLightingShaderMaterialLandscape * a_this)"
 100602,0x1412f63d0,0x141333470,3,"void BSWaterShader::Func4_1412F63D0 (BSWaterShader * a_this, undefined8 param_2)"
 100710,0x1412fd790,0x14133fcb0,4,BSRenderPass::Set
 100711,0x1412fd830,0x14133fd50,4,"BSRenderPass::SetLights"


### PR DESCRIPTION
## Summary

- SE id 100588 / VR 0x14133c260, verified via Ghidra decompile-parity (not from `addrlib.csv`'s community auto-matcher hint, which was checked and confirmed correct)
- Identical 4 unguarded texture-pointer dereferences at entry+0x7/0x2F/0x7E/0xE6 on both SE and VR binaries; a 5th site (terrain overlay texture) is already null-guarded in this function
- AE's compiler inlines this same helper into `BSLightingShader::SetupMaterial`; SE/VR keep it as a standalone function, so this id lets `EngineFixesSkyrim64`'s `lighting_shader_landscape_texture_crash` fix extend coverage to SE/VR via `RELOCATION_ID`

## Test plan
- [x] Decompiled and disassembled both SE (`sub_1412F5630`) and VR (`FUN_14133C260`) in Ghidra; confirmed byte-identical instruction shapes and deltas at all 4 sites
- [x] Confirmed call site: SE `BSLightingShader::SetupMaterial` calls this function