### PR TITLE
fix: correct GetRenderPassIndex VR address

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1956,7 +1956,7 @@
 100840,0x141306240,0x141347320,4,"void BSShaderAccumulator::RenderPersistentPassList (longlong * * passList, uint32_t renderFlags)"
 100847,0x141307160,0x141348390,3,Skyrim-Upscaler
 100852,0x141308030,0x141349270,4,"void BSBatchRenderer::ApplyPassAlphaCullState(BSRenderPass *a_this,uint *param_2,uint *param_3,undefined8 param_4,uint param_5)"
-100853,0x1413083b0,0x141349270,4,"void BSBatchRenderer::GetRenderPassIndex(BSBatchRenderer *a_this,uint *param_2)"
+100853,0x1413083b0,0x1413495f0,4,"void BSBatchRenderer::GetRenderPassIndex(BSBatchRenderer *a_this,uint *param_2)"
 100854,0x141308440,0x141349680,3,"void BSBatchRenderer::RenderPassImmediately_141308440 (BSBatchRenderer * a_Pass, uint32_t a_Technique, bool a_AlphaTest, uint32_t a_RenderFlags)"
 100871,0x1413090c0,0x14134a310,4,"LLF::void FUN_1413090c0 (BSBatchRenderer * * param_1, uint param_2)"
 100877,0x1413094a0,0x14134a6f0,4,BSBatchRenderer::sub_*


### PR DESCRIPTION
## Summary
id 100853 (`BSBatchRenderer::GetRenderPassIndex`) incorrectly carried the same VR address as id 100852 (`ApplyPassAlphaCullState`, a different function in the same file). The correct VR address for `GetRenderPassIndex`, `0x1413495f0`, was found by byte-searching SE's identical 22-byte 6-field-clear block into the VR image and confirmed against the +0x57/+0x6D patch-site delta convention already used for this function on SE/AE.

| id | field | before | after |
|---|---|---|---|
| 100853 | vr | `0x141349270` (dup of 100852) | `0x1413495f0` |

## Test plan
- [x] Single clean diff, 1 row touched
- [x] Verified in Ghidra: function at `0x1413495f0` is named `BSBatchRenderer::GetRenderPassIndex`; bytes at `+0x57` match the same block already anchored via this id on SE/AE