### PR TITLE
feat: register ActorValueStorage LocalMap ids

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -865,7 +865,10 @@
 37945,0x140638190,0x1406411a0,4,RE::ActorEquipManager::UnequipObject
 38047,0x14063cfb0,0x140646020,3,StaminaNPC::apply_deny_player_attack_or_bash
 38048,0x14063d0f0,0x140646160,3,HandleAction
+38061,0x14063dd60,0x140646df0,3,"bool GetBaseValue(ActorValueStorage*, ActorValue, float* a_value)"
+38062,0x14063de00,0x140646e90,3,"void SetBaseValue(ActorValueStorage*, ActorValue, float a_value)"
 38063,0x14063E080,0x140647110,2,"void ResetBaseValue(ActorValueStorage*, ActorValue)"
+38064,0x14063e2b0,0x140647340,3,void ClearBaseValues(ActorValueStorage*)
 38079,0x14063f810,0x1406488a0,3,bool TaskQueueInterface::ShouldUseTaskQueue()
 38085,0x14063fa50,0x140648ae0,3,void RenderFrame()
 38118,0x140640600,0x140649910,2,PapyrusTweaks::Job_VM_Update
@@ -894,6 +897,7 @@
 38900,0x14067fe60,0x1406892e0,4,LLF::AIProcess_CalculateLightValue_GetLuminance
 38966,0x140681fd0,0x14068b440,4,"void FUN_140681fd0 (undefined8 param_1, Actor * a_actor)"
 38967,0x140682020,0x14068b490,4,void FUN_140682020 (longlong param_1)
+39017,0x1406894b0,0x140692910,3,FUN_1406894b0
 39159,0x140692390,0x14069B990,2,"void ResetCachedBaseValue(CachedValues*, ActorValue)"
 39171,0x1406928c0,0x14069bec0,4,Character * Character::ctor (Character * a_this)
 39175,0x140692cd0,0x14069c2d0,3,RE::PlayerCharacter::GetArmorValue

--- a/database.csv
+++ b/database.csv
@@ -869,6 +869,7 @@
 38062,0x14063de00,0x140646e90,3,"void SetBaseValue(ActorValueStorage*, ActorValue, float a_value)"
 38063,0x14063E080,0x140647110,2,"void ResetBaseValue(ActorValueStorage*, ActorValue)"
 38064,0x14063e2b0,0x140647340,3,void ClearBaseValues(ActorValueStorage*)
+38071,0x14063ece0,0x140647d70,3,void ClearModifiers(ActorValueStorage*)
 38079,0x14063f810,0x1406488a0,3,bool TaskQueueInterface::ShouldUseTaskQueue()
 38085,0x14063fa50,0x140648ae0,3,void RenderFrame()
 38118,0x140640600,0x140649910,2,PapyrusTweaks::Job_VM_Update

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -4860,6 +4860,7 @@ sseid,aeid,confidence,name
 37964,38920,1,
 37965,38921,1,
 37968,38924,1,
+38071,39026,3,ClearModifiers
 38079,39033,3,RE::TaskQueueInterface::ShouldUseTaskQueue
 38101,39057,1,Job_Destructible_*
 38102,39058,1,Job_Pick_reference_*


### PR DESCRIPTION
## Summary

RE'd from an AE 1.6.1170 `EXCEPTION_ACCESS_VIOLATION` writing `0x4` (`movss [rbp+rbx*4], xmm6`, `rbp=0`, `rbx=1`) inside the `Actor::ActorValueStorage::LocalMap<float>` base-value cache. Registers the three sibling accessors of the already-present id 38063 `ResetBaseValue`:

- **38061** `bool GetBaseValue(ActorValueStorage*, ActorValue, float*)` - SE `0x14063dd60` / VR `0x140646df0` (AE `0x1406d02e0`)
- **38062** `void SetBaseValue(ActorValueStorage*, ActorValue, float)` - SE `0x14063de00` / VR `0x140646e90` (AE `0x1406d0380`, the crashing function)
- **38064** `void ClearBaseValues(ActorValueStorage*)` - SE `0x14063e2b0` / VR `0x140647340` (AE `0x1406d0930`)

Struct is `RE::Actor::ActorValueStorage::LocalMap<float>` (CommonLibVR `RE/A/Actor.h`): `BSFixedString actorValues` (sorted `av+1` byte keys, NUL-terminated) + `float* entries`. Entry count is `actorValues.length()`; `entries` capacity is that count rounded up to even, so an odd count reuses the existing buffer without reallocating.

Also registers **39017** (SE `0x1406894b0` / VR `0x140692910`) as an unnamed placeholder. The AE address library assigns id 39017 to AE `0x1406d0380` (= SE id 38062), but in SE/VR id space 39017 is an unrelated function - a whole-compiland SE/AE id divergence. The SE/VR pair was verified by instruction-for-instruction parity, but the function was not identified, hence the `FUN_` placeholder.

## Test plan
- [x] Decompiled all three functions on SkyrimSE.exe 1.5.97, SkyrimSE.exe 1.6.1170 and SkyrimVR.exe 1.4.15; structurally identical in all three
- [x] Confirmed callers via Ghidra xrefs (not stack-scan): `ActorValueOwner::GetBaseActorValue` (SE `0x140620f30` / AE `0x1406b2470` / VR `0x140629ce0`), `SetBaseActorValue`, `ModifyActorValue`
- [x] Confirmed VR addresses against `addrlib.csv` rows 38061/38062/38064 and independently by decompile-parity
- [x] No duplicate ids introduced; file remains id-sorted