### PR TITLE
feat: register hkbBehaviorGraph::handleEvent id (57759)

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1485,6 +1485,7 @@
 56631,0x1409c7140,0x140a01c90,4,"void* hkLifoAllocator::BufRealloc(void* a_old, std::int32_t a_oldNumBytes, std::int32_t& a_reqNumBytesInOut)"
 56801,0x1409cb860,0x140a063b0,4,"hkStringPtr * ctor_1409cb860 (undefined8 a_this, char * a_data)"
 56806,0x1409cba10,0x140a06560,4,"hkStringPtr::hkStringPtr(std::string_view a_data, const std::uint32_t a_mask, const bool a_mark)"
+57759,0x1409f0360,0x140a2aeb0,4,"void hkbBehaviorGraph::handleEvent(const hkbContext& a_context, const hkbEvent a_event)"
 57886,0x1409fbda0,0x140a368f0,4,hkbAnimationBindingSet hkbCharacter::GetAnimationBindingSet_1409FBDA0 (hkbCharacter * a_this)
 58602,0x140a0bb80,0x140a466d0,4,AnimationMotionRevoluation::hkbClipGenerator::Activate
 58603,0x140a0c270,0x140a46dc0,4,"void hkbClipGenerator::Update_140A0C270(hkbClipGenerator *a_this,longlong *param_2,undefined4 param_3)"


### PR DESCRIPTION
RE'd while resolving `crash-2026-08-03-23-57-59.log` (Havok clip-generator crash reached through a `hkbUtils::collectActiveNodesLeafFirst` call chain). Confirmed via demangled MSVC symbol, matching CommonLibVR's existing `hkbNode::handleEvent` base declaration.

## Test plan
- [x] Confirmed real function via decompile + demangled symbol match (not CrashLogger's nearest-symbol guess)
- [x] Sorted correctly by id in database.csv