### PR TITLE
feat: register hkbNode::collectActiveNodesLeafFirstRecurse id (58672)

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1493,6 +1493,7 @@
 58622,0x140a0e210,0x140a48d60,4,"void hkbClipGenerator::sub_140A0E210 (hkbClipGenerator * a_this, float a_deltaTime, float * a_outPrevLocalTime, float * a_outLocalTime, int32_t * a_outLoops, bool * a_outAtEnd)"
 58628,0x140a0f480,0x140a49fd0,4,"void sub_140A0F480 (hkbClipGenerator * a_this, hkaDefaultAnimationControl* a_hkaDefaultAnimationControl)"
 58630,0x140a0f620,0x140a4a170,4,bool hkbClipGenerator::checkAtEnd (hkbClipGenerator * param_1)
+58672,0x140a15110,0x140a4fc60,4,"void hkbNode::collectActiveNodesLeafFirstRecurse (hkbNode * a_this, hkbContext * a_context, hkbNode * a_templateNode, void * a_indexList, void * a_childIndexList, void * a_unk6, void * a_activeNodeInfoArray, void * a_unk8, bool a_deactivateFlag)"
 58817,0x140a23f10,0x140a5e8c0,4,hkaMirroredSkeleton * GetMirroredSkeleton (hkbCharacterSetup * a_this)
 59603,0x140a58c00,0x140A93600,4,"RE::hkpBoxShape* hkpBoxShape::createBoxShape(RE::hkpBoxShape*, RE::hkVector4&, float)"
 59653,0x140a5be20,0x140a96820,4,"void hkpClosestRayHitCollector::AddRayHit(const hkpCdBody& a_body, const hkpShapeRayCastCollectorOutput& a_hitInfo)"


### PR DESCRIPTION
RE'd while extending the `crash-2026-08-03-23-57-59.log` walk (see #184 for the first id from this crash chain). Confirmed via call graph: `hkbGenerator::collectActiveNodesLeafFirst` calls this once for the root node, and it recurses into itself for children, appending each node to the active-node-info array after recursing into children (leaf-first ordering) -- the actual tree-walk engine the collector delegates to. Also wraps the three known internal phase tags (`Ttclone`/`Ttupdate:activateAndSyncVars`/`Ttdeact`) per node.

## Test plan
- [x] Confirmed via call-graph relationship to already-named `hkbGenerator::collectActiveNodesLeafFirst`, not a guess
- [x] Sorted correctly by id in database.csv