### PR TITLE
feat: add SetBackHemisphereAccumulator VR ID

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -2049,6 +2049,7 @@
 101495,0x141324c30,0x141356ef0,3,"bool BSShadowDirectionalLight::UpdateCamera (BSShadowDirectionalLight * a_this, NiCamera * a_viewCamera)"
 101498,0x141324e00,0x1413570f0,2,"void BSShadowDirectionalLight::DirShadowLightCulling(BSShadowDirectionalLight* this, BSTArray<BSTArray<NiPointer<NiAVObject>>>& jobArrays, BSTArray<NiPointer<NiAVObject>>& nodes)"
 101499,0x1413251c0,0x1413574f0,3,undefined8 BSShadowDirectionalLight::Func16_1413251C0 (BSShadowDirectionalLight * a_this)
+101600,0x14132c650,0x14136f4b0,4,BSParabolicCullingProcess::SetBackHemisphereAccumulator
 101613,0x14132d040,0x14136fec0,4,void BSShadowFrustumLight::Render(std::uint32_t& a_index)
 101631,0x14132ead0,0x141371a00,3,"void GetLightingShaderDefines(uint32_t descriptor, D3D_SHADER_MACRO* defines)"
 101633,0x14132ef60,0x141371e90,3,uint32_t BSLightingShader::GetPixelTechnique (uint32_t rawTechnique)


### PR DESCRIPTION
## Summary
- Registers RelocationID 101600
  (`BSParabolicCullingProcess::SetBackHemisphereAccumulator`) for
  VR, status 4 (bit-for-bit identical opcodes, only absolute
  addresses differ).
- SE `0x14132c650`, VR `0x14136f4b0`, confirmed via Ghidra
  disassembly comparison.

## Why
open-shaders needed this to guard a vanilla-engine null-`this`
crash (the function has no null check, called from
`BSShadowLight::Accumulate` for any omni/dual-paraboloid light).
Without a VR entry, a two-arg `REL::RelocationID(se, ae)` silently
defaults `_vrID` to the SE id value, which this library didn't have
registered -- that's a hard fatal plugin-load abort on VR (`ID.h`:
"Failed to find the id within the address library"), not a graceful
skip. Found because this was the first time the consuming branch
was actually launched on VR.

## Test plan
- [x] Confirmed bit-identical disassembly between SE and VR at the
  two addresses (Ghidra)
- [x] Regenerated release addresslib (`version-1-4-15-0.csv`,
  0.247.0 -> 0.248.0) and deployed to a live VR install
- [x] Relaunched VR, confirmed the plugin loads with no "Failed to
  find the id" fatal and the consuming EngineFix installs
  successfully
