### PR TITLE
feat: register GC array/object cleanup

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1928,6 +1928,8 @@
 98149,0x1412646f0,0x1412841c0,4,"void BSScript__Internal__VirtualMachine::CleanUpStack_1412646F0(longlong param_1,longlong param_2)"
 98158,0x1412658d0,0x1412853a0,4,"void ResetState (BSScript__Internal__VirtualMachine * a_this)"
 98160,0x141266030,0x141285b00,3,RE::SaveFileHandleReaderWriter::LoadHandle
+98217,0x14126d230,0x14128d1f0,4,BSScript::Internal::VirtualMachine::ProcessArrayCleanup
+98218,0x14126d3c0,0x14128d380,4,BSScript::Internal::VirtualMachine::ProcessObjectCleanup
 98295,0x141270710,0x1412908a0,3,RE::SaveFileHandleReaderWriter::SaveHandle
 98520,0x141278110,0x1412b1380,3,BSScript::Internal::CodeTasklet::VMProcess
 98548,0x14127c1b0,0x1412b5420,3,BSScript::Internal::CodeTasklet::HandleCall


### PR DESCRIPTION
## Summary
- Adds SE ids 98217/98218 (`BSScript::Internal::VirtualMachine::ProcessArrayCleanup` /
  `::ProcessObjectCleanup`) to `database.csv` at status 4.
- Both were absent from the VR address library entirely; verified via Ghidra
  disassembly of `SkyrimVR.exe` that they're byte-identical to SE at the
  patched offsets (VR absolute address `0x14128d1f0` / `0x14128d380`),
  consistent with `addrlib.csv`'s existing automated hint for these two
  addresses.
- Ran `vr_address_tools.py . generate` locally against this branch to confirm
  both ids resolve correctly through the release pipeline (`98217,128d1f0` /
  `98218,128d380`); didn't commit the generated `version-*.csv` since that's
  gitignored and owned by the `semantic_release` CI job.

## Motivation
Used by an [EngineFixesSkyrim64](https://github.com/alandtse/EngineFixesSkyrim64)
fix porting InTheBottle/SkyrimSE-gc-bug-fix to VR
([alandtse/EngineFixesSkyrim64#70](https://github.com/alandtse/EngineFixesSkyrim64/pull/70)),
via `RELOCATION_ID(98217, 104859)` / `RELOCATION_ID(98218, 104860)`.

## Test plan
- [x] `vr_address_tools.py . generate` includes both ids at the expected VR RVAs
- [x] CI `check-csv` validation passed
- [x] End-to-end: EngineFixesSkyrim64 built against the resulting v0.255.0
      release and confirmed installing cleanly on a live VR instance