### PR TITLE
feat: add StartWaiting/StartSleeping

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -935,6 +935,8 @@
 39247,0x140695020,0x14069e620,3,BSTEventSource<LevelIncrease::Event>* LevelIncrease::GetEventSource()
 39248,0x140695110,0x14069e710,3,BSTEventSource<SkillIncrease::Event>* SkillIncrease::GetEventSource()
 39340,0x140699040,0x1406a26a0,2,PlayerCharacter::Ctor
+39343,0x14069a9d0,0x1406bae40,3,void Actor::StartSleeping(int32_t a_hours)
+39344,0x14069ab10,0x1406baf80,3,void PlayerCharacter::StartWaiting(int32_t a_hours)
 39346,0x14069abf0,0x1408ed870,2,PlayerCharacter::
 39365,0x14069c2a0,0x1406bc6c0,3,"bool PlayerCharacter::CenterOnCell_Impl(const char* a_cellName, RE::TESObjectCELL* a_cell)"
 39371,0x14069d2c0,0x1406bd770,3,po3tweaks::SitToWait::CanSleepWait


### PR DESCRIPTION
## Summary
- Registers two new address-library ids with their VR addresses:
  - `39343` — `Actor::StartSleeping(int32_t a_hours)` — SE `0x14069a9d0` -> VR `0x1406bae40`
  - `39344` — `PlayerCharacter::StartWaiting(int32_t a_hours)` — SE `0x14069ab10` -> VR `0x1406baf80`
- Status 3 (manually entered, automatic-tools-suggested verification): both VR addresses were found via a Ghidra Version Tracking (SE->VR) session as AVAILABLE (unaccepted) matches, then confirmed logic-identical by decompiling both sides — struct offsets differ between SE and VR (`PlayerCharacter::sleepSeconds` sits at a different in-memory offset per runtime) so this isn't bit-for-bit identical, hence status 3 rather than 4.
- Companion CommonLibVR PR binding these functions: alandtse/CommonLibSSE-NG#331.

## Test plan
- [x] `python vr_address_tools.py . generate` from the `vr_address_tools` tool repo picks up both new rows; confirmed both ids appear in the generated `version-1-4-15-0.csv` with the correct VR offsets (`39343,06bae40` / `39344,06baf80`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSJa7XDif7Rn3AAbUerpKz