### PR TITLE
feat: add BGSDecalManager::ApplyDecal

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -149,6 +149,7 @@
 14653,0x14019b290,0x1401aafc0,4,void TESModelTextureSwap::sub_14019B290 (TESModelTextureSwap * a_this)
 14704,0x14019d510,0x1401ad250,3,BSTEventSource<TESHarvestedEvent::ItemHarvested>* TESHarvestedEvent::GetEventSource()
 14809,0x1401a1730,0x1401b1470,3,RE::TESForm::GetWeight
+15029,0x1401ad2f0,0x1401bd040,2,"void BGSDecalManager::ApplyDecal(DECAL_CREATION_DATA*, bool, BGSDecalGroup*)"
 15073,0x1401b02a0,0x1401c02b0,4,void hkpAllRayHitTempCollector::Reset()
 15118,0x1401b13f0,0x1401c1400,3,RE::BGSDecalManager::RemoveItem
 15157,0x1401b2730,0x1401c2740,3,"bool BGSDynamicPersistenceManager::PromoteReference(TESObjectREFR* a_refr, TESForm* a_owner)"
@@ -18451,4 +18452,3 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
-15029,0x1401ad2f0,0x1401bd040,2,"void BGSDecalManager::ApplyDecal(DECAL_CREATION_DATA*, bool, BGSDecalGroup*)"

--- a/database.csv
+++ b/database.csv
@@ -18451,3 +18451,4 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+15029,0x1401ad2f0,0x1401bd040,2,"void BGSDecalManager::ApplyDecal(DECAL_CREATION_DATA*, bool, BGSDecalGroup*)"


### PR DESCRIPTION
## Summary
- Registers a new address-library id:
  - `15029` — `BGSDecalManager::ApplyDecal(DECAL_CREATION_DATA*, bool, BGSDecalGroup*)` — SE `0x1401ad2f0` -> VR `0x1401bd040`
- Status 2 (manually entered, assumed verified): confirmed via Ghidra Version Tracking (SE->VR) accepted match, then verified logic-identical by decompiling both sides -- same `bDecals`/`bForceAllDecals` gate, same `fDecalLOD0_Display` distance check, same `NiAVObject::FindEligibleAttachNode` call. Not promoted to status 4 since a full byte-level instruction diff wasn't done.
- Companion CommonLibVR PR binding this function: alandtse/CommonLibSSE-NG#335

## Test plan
- [x] `python vr_address_tools.py . generate -rv 0.260.0` from the `vr_address_tools` tool repo picks up the new row; confirmed `15029,01bd040` appears in the generated `version-1-4-15-0.csv`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFVUotH6aA9MfnEkfEucUF