### PR TITLE
feat: add GetNextPassSlotInGroup

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -2065,6 +2065,7 @@
 100840,0x141306240,0x141347320,4,"void BSShaderAccumulator::RenderPersistentPassList (longlong * * passList, uint32_t renderFlags)"
 100843,0x141306db0,0x141347fe0,4,"void BSBatchRenderer::ClearAllRenderPasses(BSBatchRenderer * a_this)"
 100847,0x141307160,0x141348390,3,Skyrim-Upscaler
+100851,0x141307fc0,0x141349200,4,"bool BSBatchRenderer::GetNextPassSlotInGroup(BSRenderPass *a_this, uint32_t param_2, uint32_t *param_3)"
 100852,0x141308030,0x141349270,4,"void BSBatchRenderer::ApplyPassAlphaCullState(BSRenderPass *a_this,uint *param_2,uint *param_3,undefined8 param_4,uint param_5)"
 100853,0x1413083b0,0x1413495f0,4,"void BSBatchRenderer::GetRenderPassIndex(BSBatchRenderer *a_this,uint *param_2)"
 100854,0x141308440,0x141349680,3,"void BSBatchRenderer::RenderPassImmediately_141308440 (BSBatchRenderer * a_Pass, uint32_t a_Technique, bool a_AlphaTest, uint32_t a_RenderFlags)"

--- a/se_ae.csv
+++ b/se_ae.csv
@@ -8313,6 +8313,7 @@ sseid,aeid,confidence,name
 100841,107631,1,
 100847,107637,1,
 100848,107638,1,BSBatchRenderer::Func3_*
+100851,107641,1,BSBatchRenderer::GetNextPassSlotInGroup
 100852,107642,1,BSBatchRenderer::sub_*
 100854,107644,1,
 100855,107645,1,


### PR DESCRIPTION
## Summary
Adds AE id and address for `BSBatchRenderer::GetNextPassSlotInGroup` (id 100851), previously mapped for SE only.

- AE id 107641, verified against `offsets-1-6-1170.0.csv` (`107641,14f3950`) **and cross-checked against `offsets-1-7-104.0.csv`** (`107641,155fed0`) -- confirmed byte-identical at both AE point releases via live disassembly in Ghidra, not just id-lookup.
- Address `0x141349200`, read live from `SkyrimVR.exe` in Ghidra. Status 4 verified rigorously: **all 103 bytes of the function body compared byte-for-byte** against SE (`SkyrimSE.exe`), not just a leading-instruction spot check -- identical.
- AE's own implementation differs in register allocation/encoding from SE (same pattern already noted for the neighboring `ApplyPassAlphaCullState`/id 100852), so this only adds the id/address mapping, not a claim that SE/AE share identical patch bytes.
- **Signature corrected**: the initially-recorded signature (`void ...(BSRenderPass *a_this)`) was Ghidra's incomplete auto-analyzed one, missing two real parameters. Decompilation and disassembly both confirm the function reads RDX and R8 as inputs and returns a bool (`SETZ AL` immediately before `RET`), none of which the default calling-convention analysis surfaced. Corrected to `bool BSBatchRenderer::GetNextPassSlotInGroup(BSRenderPass *a_this, uint32_t param_2, uint32_t *param_3)`, using this file's own `param_N` convention for the two parameters whose exact semantics aren't independently confirmed (matching the existing entries for e.g. id 100852).

## Why
`EngineFixesSkyrim64` PR #75 (a render-pass UAF guard) currently anchors this function by a raw offset instead of `REL::ID(100851)`, since the id had no mapping yet. This closes that gap so the PR (and a merged SE/AE follow-up, #76) can use the id directly.

## Verification
- `database.csv`: new row `100851,0x141307fc0,0x141349200,4,"bool BSBatchRenderer::GetNextPassSlotInGroup(BSRenderPass *a_this, uint32_t param_2, uint32_t *param_3)"` inserted in id order between existing 100847/100852 rows.
- `se_ae.csv`: new row `100851,107641,1,BSBatchRenderer::GetNextPassSlotInGroup`, in id order between existing 100848/100852 rows, consistent with the neighboring rows' `+6790` SE->AE id offset pattern for this cluster (100852->107642, 100854->107644), confirmed against the canonical AE offsets CSVs rather than assumed from the pattern alone.
- CSV quoting matches this repo's actual `QUOTE_MINIMAL` convention (verified by running `scripts/autofix_csv_quotes.py` locally, since `check-csv.yml`'s bot hasn't run since 2025-09-23) -- unquoted where the name has no internal comma, quoted where it now does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAtA2W2RXLuKGJiZaacvjs