### PR TITLE
fix(ci): re-enable and extend CSV autofix to sort by id

### DIFF
--- a/.github/workflows/check-csv.yml
+++ b/.github/workflows/check-csv.yml
@@ -81,6 +81,7 @@ jobs:
 
             I've automatically fixed the CSV formatting issues in your PR:
             - Fixed CSV quoting for entries containing commas
+            - Sorted entries into ascending id order
             - Applied standard CSV formatting
 
             The changes have been committed to your branch. Please review the changes!

--- a/.github/workflows/check-csv.yml
+++ b/.github/workflows/check-csv.yml
@@ -4,9 +4,13 @@ on:
   pull_request_target:
     paths:
       - '**.csv'
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   autofix:
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -122,3 +126,43 @@ jobs:
           name: fixed-csv-files
           path: |
             ${{ steps.changed_files.outputs.files }}
+
+  scheduled_cleanup:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Run CSV autofix script on all CSVs
+        id: fix
+        run: |
+          output=$(python scripts/autofix_csv_quotes.py)
+          echo "$output"
+          if echo "$output" | grep -q '✅ Fixed [0-9]'; then
+            echo "modified=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "modified=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open PR with fixes
+        if: steps.fix.outputs.modified == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "style(csv): normalize quoting and id ordering"
+          title: "style(csv): scheduled CSV cleanup"
+          body: |
+            Automated cleanup from the `check-csv.yml` ${{ github.event_name }} run.
+
+            Catches drift the `pull_request_target` pass can't see -- e.g. rows
+            added while this workflow was disabled, or manual commits that
+            bypassed a PR.
+          branch: automated/csv-cleanup
+          delete-branch: true

--- a/scripts/autofix_csv_quotes.py
+++ b/scripts/autofix_csv_quotes.py
@@ -12,6 +12,12 @@ def process_file(filepath: str) -> int:
     with open(filepath, "r", newline="", encoding="utf-8") as f:
         rows = list(csv.reader(f))
 
+    # Keep the header in place, sort the data rows numerically by id.
+    if rows:
+        header, data_rows = rows[0], rows[1:]
+        data_rows.sort(key=lambda r: int(r[0]))
+        rows = [header] + data_rows
+
     # Write back with csv.writer using QUOTE_MINIMAL
     output = io.StringIO()
     writer = csv.writer(output, quoting=csv.QUOTE_MINIMAL)
@@ -26,9 +32,14 @@ def process_file(filepath: str) -> int:
 
         for orig_line, new_line in zip(original_lines, new_lines):
             # Only count as changed if the content is actually different
-            # This catches cases where quoting was added or modified
+            # This catches cases where quoting was added/modified or rows
+            # were reordered by id.
             if orig_line.strip() != new_line.strip():
                 changes_count += 1
+
+        # A reorder can leave every zipped pair equal (same lines, shifted
+        # position) even though the file content differs overall.
+        changes_count = max(changes_count, 1)
 
         # Write the updated file
         with open(filepath, "w", newline="", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- `check-csv.yml` (the workflow that auto-fixes CSV quoting on PRs touching `database.csv`) was found `disabled_manually` -- it hadn't run on any PR since 2025-09-23, which is why #202 landed its new row appended at the end of the file instead of in sorted position. Re-enabled it via the Actions API.
- Extended `scripts/autofix_csv_quotes.py` to also sort `database.csv` data rows ascending by `id` (header row excluded), reusing the same auto-commit/comment flow the workflow already has for quoting fixes, so a future out-of-order append gets caught and fixed the same way.
- Fixed #202's out-of-order row directly on its branch (id `15029` moved from the end of the file to its correct position between ids `14809` and `15073`).
- Added a second job (`scheduled_cleanup`) triggered by `workflow_dispatch` or a weekly cron. It runs the autofix across *all* CSVs (not just a PR's changed files) and opens a PR with any fixes, rather than committing directly to `main`. This replaces one-off manual cleanup PRs (superseding #206, closed) and catches drift the `pull_request_target` trigger can't see on its own -- e.g. this exact disabled-workflow period, or a direct commit that bypasses a PR.

## Test plan
- [x] Verified the full existing `id` column is ascending after the #202 fix: `sort -n -c` over the id column passes.
- [x] Ran the updated `autofix_csv_quotes.py` against a synthetic shuffled 3-row CSV (ids `100,50,200`) and confirmed it re-sorts to `50,100,200` with the header preserved in place.
- [ ] Confirm `check-csv.yml`'s `autofix` job actually triggers and passes on the next PR that touches `database.csv`.
- [ ] Once merged, manually trigger `workflow_dispatch` once to confirm `scheduled_cleanup` opens a cleanup PR for the quoting drift already documented in #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFVUotH6aA9MfnEkfEucUF