### PR TITLE
feat: register grass optimizations

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -1831,10 +1831,10 @@
 74397,0x140d3dce0,0x140d86c70,4,"static bool BSPortalGraphEntry::func2(RE::BSPortalGraphEntry* first, RE::BSPortalGraphEntry* second)"
 74398,0x140d3dde0,0x140d86d70,4,"void BSPortalGraphEntry::AddVisibilityToMap(void* a_space, BSCompoundFrustum* a_compoundFrustum)"
 74491,0x140d426f0,0x140d8b6b0,4,uint16_t FloatToHalf (float a_input)
-74596,0x140d464e0,0x140d8f410,4,"ulonglong FUN_140d464e0(longlong param_1, longlong param_2)"
-74599,0x140d46b20,0x140d8fa50,4,"void FUN_140d46b20(longlong param_1, longlong param_2, longlong param_3)"
+74596,0x140d464e0,0x140d8f410,4,"ulonglong GrassManager::FindOrAddMultiBoundShape(GrassManager* param_1, longlong param_2)"
+74599,0x140d46b20,0x140d8fa50,4,"void GrassManager::QueueMultiBoundShapeLoad(GrassManager* param_1, longlong param_2, longlong param_3)"
 74601,0x140d46da0,0x140d8fcd0,4,"void FUN_140d46da0 (longlong param_1, uint param_2, longlong param_3, uint param_4, char param_5)"
-74607,0x140d47590,0x140d904c0,4,"BSMultiBoundShape* FUN_140d47590(BSMultiBoundShape* param_1, NiPoint3* param_2, NiPoint3* param_3, bool param_4, undefined4 param_5, int param_6, longlong param_7, int param_8)"
+74607,0x140d47590,0x140d904c0,4,"BSMultiBoundShape* BSMultiBoundShape::LoadFromStream(BSMultiBoundShape* param_1, NiPoint3* param_2, NiPoint3* param_3, bool param_4, undefined4 param_5, int param_6, longlong param_7, int param_8)"
 74621,0x140d47af0,0x140d90a20,4,"void BSIOStreamTraits::Write (BSIOStreamTraits * a_this, void * a_1, uint a_2)"
 74702,0x140d4c7e0,0x140d956c0,4,"bool BSOcclusionPlane::WithinFrustumDistFirst(const NiFrustumPlanes* a_planes, const NiPoint3* a_point)"
 74812,0x140d517c0,0x140d9a5e0,4,bool BSCullingProcess::AddShared(NiAVObject* a_object)

--- a/database.csv
+++ b/database.csv
@@ -1832,9 +1832,9 @@
 74398,0x140d3dde0,0x140d86d70,4,"void BSPortalGraphEntry::AddVisibilityToMap(void* a_space, BSCompoundFrustum* a_compoundFrustum)"
 74491,0x140d426f0,0x140d8b6b0,4,uint16_t FloatToHalf (float a_input)
 74596,0x140d464e0,0x140d8f410,4,"ulonglong FUN_140d464e0(longlong param_1, longlong param_2)"
-74599,0x140d46b20,0x140d8fa50,4,"undefined FUN_140d46b20(longlong param_1, longlong param_2, longlong param_3)"
+74599,0x140d46b20,0x140d8fa50,4,"void FUN_140d46b20(longlong param_1, longlong param_2, longlong param_3)"
 74601,0x140d46da0,0x140d8fcd0,4,"void FUN_140d46da0 (longlong param_1, uint param_2, longlong param_3, uint param_4, char param_5)"
-74607,0x140d47590,0x140d904c0,4,"BSMultiBoundShape* FUN_140d47590(BSMultiBoundShape* param_1, undefined4* param_2, undefined4* param_3, char param_4, undefined4 param_5, int param_6, longlong param_7, int param_8)"
+74607,0x140d47590,0x140d904c0,4,"BSMultiBoundShape* FUN_140d47590(BSMultiBoundShape* param_1, NiPoint3* param_2, NiPoint3* param_3, bool param_4, undefined4 param_5, int param_6, longlong param_7, int param_8)"
 74621,0x140d47af0,0x140d90a20,4,"void BSIOStreamTraits::Write (BSIOStreamTraits * a_this, void * a_1, uint a_2)"
 74702,0x140d4c7e0,0x140d956c0,4,"bool BSOcclusionPlane::WithinFrustumDistFirst(const NiFrustumPlanes* a_planes, const NiPoint3* a_point)"
 74812,0x140d517c0,0x140d9a5e0,4,bool BSCullingProcess::AddShared(NiAVObject* a_object)
@@ -2055,7 +2055,7 @@
 99947,0x1412cc3c0,0x14130af00,3,BSShaderAccumulator::ShadowMapOrMask
 99957,0x1412cca70,0x14130b6b0,4,"BSBatchRenderer::GeometryGroup * BSShaderAccumulator::StartGroupingAlphas(BSShaderAccumulator * a_this, NiBound * a_bound)"
 99963,0x1412cce40,0x14130ba60,4,"void BSBatchRenderer::RenderBatches (BSBatchRenderer * This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup)"
-99996,0x1412ce260,0x14130d090,3,undefined BSGrassShader::Func6(BSGrassShader* a_this)
+99996,0x1412ce260,0x14130d090,3,"void BSGrassShader::SetupGeometry(BSGrassShader* a_this, BSRenderPass* a_pass, uint a_flags)"
 100000,0x1412ceb10,0x14130da10,4,"void fogMethod (undefined8 param_1, int param_2)"
 100004,0x1412ced50,0x14130dc60,3,BSLightingShaderMaterial* BSLightingShaderMaterial::Ctor()
 100016,0x1412cfbc0,0x14130ead0,3,RE::BSLightingShaderMaterialBase::CreateMaterial

--- a/database.csv
+++ b/database.csv
@@ -1831,10 +1831,10 @@
 74397,0x140d3dce0,0x140d86c70,4,"static bool BSPortalGraphEntry::func2(RE::BSPortalGraphEntry* first, RE::BSPortalGraphEntry* second)"
 74398,0x140d3dde0,0x140d86d70,4,"void BSPortalGraphEntry::AddVisibilityToMap(void* a_space, BSCompoundFrustum* a_compoundFrustum)"
 74491,0x140d426f0,0x140d8b6b0,4,uint16_t FloatToHalf (float a_input)
-74596,0x140d464e0,0x140d8f410,4,GrassOptimizations::ReadGroupHeaderStreamTraits target (group GID buffer read)
-74599,0x140d46b20,0x140d8fa50,4,GrassOptimizations::ReadGroupHeaderStreamTraits target (queued group GID buffer read)
+74596,0x140d464e0,0x140d8f410,4,"ulonglong FUN_140d464e0(longlong param_1, longlong param_2)"
+74599,0x140d46b20,0x140d8fa50,4,"undefined FUN_140d46b20(longlong param_1, longlong param_2, longlong param_3)"
 74601,0x140d46da0,0x140d8fcd0,4,"void FUN_140d46da0 (longlong param_1, uint param_2, longlong param_3, uint param_4, char param_5)"
-74607,0x140d47590,0x140d904c0,4,GrassOptimizations::ReadInstanceGroupStreamTraits target (BSMultiBoundShape stream ctor)
+74607,0x140d47590,0x140d904c0,4,"BSMultiBoundShape* FUN_140d47590(BSMultiBoundShape* param_1, undefined4* param_2, undefined4* param_3, char param_4, undefined4 param_5, int param_6, longlong param_7, int param_8)"
 74621,0x140d47af0,0x140d90a20,4,"void BSIOStreamTraits::Write (BSIOStreamTraits * a_this, void * a_1, uint a_2)"
 74702,0x140d4c7e0,0x140d956c0,4,"bool BSOcclusionPlane::WithinFrustumDistFirst(const NiFrustumPlanes* a_planes, const NiPoint3* a_point)"
 74812,0x140d517c0,0x140d9a5e0,4,bool BSCullingProcess::AddShared(NiAVObject* a_object)
@@ -2055,7 +2055,7 @@
 99947,0x1412cc3c0,0x14130af00,3,BSShaderAccumulator::ShadowMapOrMask
 99957,0x1412cca70,0x14130b6b0,4,"BSBatchRenderer::GeometryGroup * BSShaderAccumulator::StartGroupingAlphas(BSShaderAccumulator * a_this, NiBound * a_bound)"
 99963,0x1412cce40,0x14130ba60,4,"void BSBatchRenderer::RenderBatches (BSBatchRenderer * This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup)"
-99996,0x1412ce260,0x14130d090,3,RE::BSGrassShader::Func6 (vtable slot 6, SetupGeometry)
+99996,0x1412ce260,0x14130d090,3,undefined BSGrassShader::Func6(BSGrassShader* a_this)
 100000,0x1412ceb10,0x14130da10,4,"void fogMethod (undefined8 param_1, int param_2)"
 100004,0x1412ced50,0x14130dc60,3,BSLightingShaderMaterial* BSLightingShaderMaterial::Ctor()
 100016,0x1412cfbc0,0x14130ead0,3,RE::BSLightingShaderMaterialBase::CreateMaterial

--- a/database.csv
+++ b/database.csv
@@ -1831,7 +1831,10 @@
 74397,0x140d3dce0,0x140d86c70,4,"static bool BSPortalGraphEntry::func2(RE::BSPortalGraphEntry* first, RE::BSPortalGraphEntry* second)"
 74398,0x140d3dde0,0x140d86d70,4,"void BSPortalGraphEntry::AddVisibilityToMap(void* a_space, BSCompoundFrustum* a_compoundFrustum)"
 74491,0x140d426f0,0x140d8b6b0,4,uint16_t FloatToHalf (float a_input)
+74596,0x140d464e0,0x140d8f410,4,GrassOptimizations::ReadGroupHeaderStreamTraits target (group GID buffer read)
+74599,0x140d46b20,0x140d8fa50,4,GrassOptimizations::ReadGroupHeaderStreamTraits target (queued group GID buffer read)
 74601,0x140d46da0,0x140d8fcd0,4,"void FUN_140d46da0 (longlong param_1, uint param_2, longlong param_3, uint param_4, char param_5)"
+74607,0x140d47590,0x140d904c0,4,GrassOptimizations::ReadInstanceGroupStreamTraits target (BSMultiBoundShape stream ctor)
 74621,0x140d47af0,0x140d90a20,4,"void BSIOStreamTraits::Write (BSIOStreamTraits * a_this, void * a_1, uint a_2)"
 74702,0x140d4c7e0,0x140d956c0,4,"bool BSOcclusionPlane::WithinFrustumDistFirst(const NiFrustumPlanes* a_planes, const NiPoint3* a_point)"
 74812,0x140d517c0,0x140d9a5e0,4,bool BSCullingProcess::AddShared(NiAVObject* a_object)
@@ -2052,6 +2055,7 @@
 99947,0x1412cc3c0,0x14130af00,3,BSShaderAccumulator::ShadowMapOrMask
 99957,0x1412cca70,0x14130b6b0,4,"BSBatchRenderer::GeometryGroup * BSShaderAccumulator::StartGroupingAlphas(BSShaderAccumulator * a_this, NiBound * a_bound)"
 99963,0x1412cce40,0x14130ba60,4,"void BSBatchRenderer::RenderBatches (BSBatchRenderer * This, uint32_t StartRange, uint32_t EndRanges, uint32_t RenderFlags, int GeometryGroup)"
+99996,0x1412ce260,0x14130d090,3,RE::BSGrassShader::Func6 (vtable slot 6, SetupGeometry)
 100000,0x1412ceb10,0x14130da10,4,"void fogMethod (undefined8 param_1, int param_2)"
 100004,0x1412ced50,0x14130dc60,3,BSLightingShaderMaterial* BSLightingShaderMaterial::Ctor()
 100016,0x1412cfbc0,0x14130ead0,3,RE::BSLightingShaderMaterialBase::CreateMaterial


### PR DESCRIPTION
## Summary
Registers 4 previously-uncataloged VR (1.4.15) addresses needed by Open Shaders' upcoming VR support for upstream Community Shaders' new Grass Optimizations feature. All four were missing from `database.csv` entirely (the 2-arg `RELOCATION_ID(se, ae)` pattern used for them would otherwise hard-fatal on VR plugin load).

- `74599`, `74596`: internal grass-cell stream-group-header readers, called from `LoadGrassType` (RelocationID 15206, already registered). Resolved by finding VR's equivalent of that caller and matching the two back-to-back-in-SE calls against a single runtime-branched call site in VR. Status 4 — bit-identical byte offset to SE (`+0x36` / `+0x2F`).
- `74607`: the `BSMultiBoundShape` stream constructor both of the above call into. Status 4 — bit-identical offset (`+0xCF`).
- `99996` (`RE::BSGrassShader::Func6`, vtable slot 6 / SetupGeometry): resolved directly via `Offsets_VTABLE.h`'s existing `VTABLE_BSGrassShader` VR entry, reading vtable slot 6. Status 3 — VR's compiled version has an extra per-frame buffer-cache-check block SE doesn't have, so a hook offset computed relative to SE's layout lands on the wrong instruction.

## Verification
Each SE→VR mapping was confirmed by disassembling both binaries in Ghidra and checking the call targets/instruction shapes at the resolved offsets match structurally (not just "the function exists"), following the `database.csv` status-field criteria in the repo's own review notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)