### PR TITLE
feat: register VR addresses for po3 sync's new RE

### DIFF
--- a/database.csv
+++ b/database.csv
@@ -18494,3 +18494,9 @@
 5375528368,0x140680db0,0x14068a230,3,RE::AIProcess::SetActorRefraction
 5388393136,0x1412c5ab0,0x141303ea0,3,RE::BSLightingShaderProperty::InvalidateTextures
 5399981752,0x141dd2eb8,0x141e901a8,4,"CalculateMyCriticalHitChance"
+100776,0x141301c50,0x141344550,2,BSCubeMapCamera* BSCubeMapCamera::Ctor()
+100779,0x141301fa0,0x1413448a0,2,void BSCubeMapCamera::SetFace(Face a_face)
+75639,0x140d74bb0,0x140dc79d0,2,"void RenderTargetManager::CreateDepthStencilTarget(RENDER_TARGET_DEPTHSTENCIL a_renderTarget, const DepthStencilTargetProperties& a_properties)"
+75640,0x140d74be0,0x140dc7a20,2,"void RenderTargetManager::CreateCubeMapRenderTarget(RENDER_TARGET_CUBEMAP a_renderTarget, const CubeMapRenderTargetProperties& a_properties)"
+75647,0x140d74d10,0x140dc7b50,2,"void RenderTargetManager::SetCurrentDepthStencilTarget(RENDER_TARGET_DEPTHSTENCIL a_renderTarget, SetRenderTargetMode a_mode, std::uint32_t a_slice)"
+75648,0x140d74d60,0x140dc7ba0,2,"void RenderTargetManager::SetCurrentCubeMapRenderTarget(RENDER_TARGET_CUBEMAP a_renderTarget, SetRenderTargetMode a_mode, std::uint32_t a_faceIndex, bool a_updateViewport)"


### PR DESCRIPTION
Registers 6 VR addresses for classes touched by the CommonLibSSE-NG po3-upstream-sync PR (alandtse/CommonLibSSE-NG#339): `BSCubeMapCamera::Ctor`/`SetFace`, and `RenderTargetManager`'s 4 create/set methods.

Sourced from `addrlib.csv`, cross-verified against existing Ghidra symbol names on `SkyrimVR.exe` before trusting them (status 2). Explicitly excludes id `67749` (`BSAudioManager::StopAllSounds`'s AE-only native call) — despite `addrlib.csv` showing an SE/VR pair for that same digit sequence, it's a coincidental collision with an unrelated SE function; the real id lives in AE's separate `aeid` numbering space with no VR equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAtA2W2RXLuKGJiZaacvjs