### PR TITLE
ci: scope CSV autofix to database.csv

### DIFF
--- a/.github/workflows/check-csv.yml
+++ b/.github/workflows/check-csv.yml
@@ -141,10 +141,10 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Run CSV autofix script on all CSVs
+      - name: Run CSV autofix script on database.csv
         id: fix
         run: |
-          output=$(python scripts/autofix_csv_quotes.py)
+          output=$(python scripts/autofix_csv_quotes.py database.csv)
           echo "$output"
           if echo "$output" | grep -q '✅ Fixed [0-9]'; then
             echo "modified=true" >> "$GITHUB_OUTPUT"

--- a/scripts/autofix_csv_quotes.py
+++ b/scripts/autofix_csv_quotes.py
@@ -55,12 +55,11 @@ def main():
     if len(sys.argv) > 1:
         files_to_process = sys.argv[1:]
     else:
-        # Default behavior: find all CSV files
-        files_to_process = []
-        for root, _, files in os.walk("."):
-            for file in files:
-                if file.endswith(".csv"):
-                    files_to_process.append(os.path.join(root, file))
+        # Default behavior: only database.csv is expected to have a leading
+        # decimal `id` column safe to numeric-sort -- every other CSV in this
+        # repo uses a different schema (id last, hex-keyed, etc.) and walking
+        # the whole tree here previously crashed on them.
+        files_to_process = ["database.csv"]
 
     total_fixes = 0
     for filepath in files_to_process:

--- a/scripts/autofix_csv_quotes.py
+++ b/scripts/autofix_csv_quotes.py
@@ -55,10 +55,8 @@ def main():
     if len(sys.argv) > 1:
         files_to_process = sys.argv[1:]
     else:
-        # Default behavior: only database.csv is expected to have a leading
-        # decimal `id` column safe to numeric-sort -- every other CSV in this
-        # repo uses a different schema (id last, hex-keyed, etc.) and walking
-        # the whole tree here previously crashed on them.
+        # Keep the default scoped to database.csv; other CSV schemas are not
+        # safe to numeric-sort.
         files_to_process = ["database.csv"]
 
     total_fixes = 0


### PR DESCRIPTION
Answers "why is [se-ae-attempted-match.csv etc.] even on the list?" from run https://github.com/alandtse/skyrim_vr_address_library/actions/runs/34193252027

`scheduled_cleanup` calls `autofix_csv_quotes.py` with no arguments, and the script's default (no args) walks the entire repo tree grabbing every `*.csv`, then numeric-sorts each by its first column. `database.csv` is the only file with that schema (`id,sse,vr,status,name`, id first, decimal) — every other CSV here uses something different (`aeid,ae_addr`; `vr,sse,id` with id last; hex-keyed files), so the sort crashes on real, long-standing data outside `database.csv`'s scope (`se-ae-attempted-match.csv`'s `14000102D` id has been there since 2022 — unrelated to this workflow's actual purpose).

Scoped both the `scheduled_cleanup` job's invocation and the script's own no-args default to `database.csv` only. Verified locally: `python scripts/autofix_csv_quotes.py database.csv` runs clean, no changes needed (database.csv is already correctly formatted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAtA2W2RXLuKGJiZaacvjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CSV quote autofixing now targets `database.csv` by default, reducing the risk of unintended changes to other CSV files.
  * Automated cleanup is limited to the intended database file while still supporting explicitly specified files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->